### PR TITLE
Tilpasse til BRegDCAT-AP v.1.05

### DIFF
--- a/docs/01_Introduksjon.adoc
+++ b/docs/01_Introduksjon.adoc
@@ -1,4 +1,3 @@
-
 = Innledning
 
 Formålet med standarden er å legge til rette for utveksling av beskrivelser av datasett og datatjenester, og å lette søk etter datasett og datatjenester. Standarden vil gjelde datasett og datatjenester som forvaltes av offentlig sektor, og som beskrives med tanke på oppføring i en katalog eller «inventarliste». Standarden vil støtte søking i og deling av datasett på tvers av offentlig sektor (gjenbruk) og legge til rette for viderebruk i privat sektor. Standarden er således nyttig både for offentlig sektor selv og for næringsliv og sivilsamfunn for øvrig.

--- a/docs/02_Avvik.adoc
+++ b/docs/02_Avvik.adoc
@@ -7,52 +7,13 @@ Denne versjonen av DCAT-AP-NO avviker BRegDCAT-AP på følgende måter:
 [cols="15,15,35,35"]
 |===
 |*Klasse-/egenskapsnavn*|*URI for klassen/egenskapen*|*Avvik*|*Forklaring*
-|Aktør: navn|foaf:name|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Aktør: organisasjonsidentifikator|dct:identifier|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1
-|Aktør: utgivertype|dct:type|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
 |Datasett: begrep|dct:subject|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1
-|Datasett: er påkrevd av|dct:isRequiredBy|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1
-|Datasett: er referert av|dct:isReferencedBy|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Datasett: erstatter|dct:replaces|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1
-|Datasett: erstattes av|dct:isReplacedBy|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1
-|Datasett: følger|cpsv:follows|Endret fra valgfri til anbefalt|Denne erstatter anbefalt egenskap `Datasett: skjermingshjemmel` i DCAT-AP-NO v.1.1
-|Datasett: krever|dct:requires|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1
-|Datasett: refererer til|dct:references|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1
-|Datasett: tema|dcat:theme|Endret fra anbefalt til obligatorisk|Allerede i DCAT-AP-NO v.1.1
+|Datasett: følger|cpsv:follows|Endret fra valgfri til anbefalt|Denne erstatter anbefalt egenskap Datasett: skjermingshjemmel i DCAT-AP-NO v.1.1
+|Datasett: tema|dcat:theme|Endret fra anbefalt til obligatorisk, dermed også kardinalitet|Allerede i DCAT-AP-NO v.1.1
 |Datasett: tilgangsnivå|dct:accessRights|Endret fra valgfri til anbefalt|Allerede i DCAT-AP-NO v.1.1
-|Datasett: utgiver|dct:publisher|Endret fra anbefalt til obligatorisk|Allerede i DCAT-AP-NO v.1.1
-|Datatjeneste: i samsvar med|dct:conformsTo|Ikke eksplisitt tatt med i BRegDCAT-AP|For bl.a. å kunne referere til en informasjonsmodell
-|Distribusjon: format|dct:format|Endret fra anbefalt til obligatorisk|Allerede i DCAT-AP-NO v.1.1
-|Distribusjon: format|dct:format|Range endret fra `dct:MediaTypeOrExtent` til `dct:MediaType` |
-|Distribusjon: format|dct:format|Multiplisitet endret fra 0..*1* til 1..*n* |Allerede i DCAT-AP-NO v.1.1
-|Distribusjon: geografisk oppløsning|dcat:spatialResolutionInMeters|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Distribusjon: i samsvar med|dct:conformsTo|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Distribusjon: pakkeformat|dcat:packageFormat|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Distribusjon: policy|odrl:hasPolicy|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Distribusjon: rettigheter|dct:rights|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Distribusjon: status|adms:status|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Distribusjon: tidsromsoppløsning|dcat:temporalResolution|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Distribusjon: tittel|dct:title|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Identifikator: notasjon|skos:notation|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Katalog: er del av|dct:isPartOf|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Katalog: har del|dct:hasPart|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Lisensdokument: lisenstype|dct:type|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Lokasjon: geometri|locn:geometry|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Lokasjon: område|dcat:bbox|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Lokasjon: senterpunkt|dcat:centroid|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Regulativ ressurs: referanse|rdfs:seeAlso|Ikke eksplisitt tatt med i BRegDCAT-AP|For å kunne ha med referanse til en regulativ ressurs
-|Relasjon: relasjon|dct:relation|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Relasjon: rolle|dcat:hadRole|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Sjekksum|spdx:Checksum|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Sjekksum: algoritme|spdx:algorithm|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Sjekksum: sjekksumverdi|spdx:checksumValue|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
+|Datasett: utgiver|dct:publisher|Endret fra anbefalt til obligatorisk, dermed også kardinalitet|Allerede i DCAT-AP-NO v.1.1
+|Distribusjon: format|dct:format|Endret fra anbefalt til obligatorisk, dermed også kardinalitet|Allerede i DCAT-AP-NO v.1.1
+|Distribusjon: format|dct:format|Range endret fra dct:MediaTypeOrExtent til dct:MediaType|
 |Tema|skos:Concept|Endret fra anbefalt til obligatorisk|Allerede i DCAT-AP-NO v.1.1
-|Tema: foretrukket tittel|skos:prefLabel|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
 |Tematisk skjema|skos:ConceptScheme|Endret fra anbefalt til obligatorisk|Allerede i DCAT-AP-NO v.1.1
-|Tematisk skjema: tittel|dct:title|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Tidsrom: begynnelse|time:hasBeginning|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Tidsrom: slutt|time:hasEnd|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Tidsrom: sluttdato/tid|dcat:endDate|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Tidsrom: startdato/tid|dcat:startDate|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Utgivertype|skos:Concept|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1 og DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
 |===

--- a/docs/02_Avvik.adoc
+++ b/docs/02_Avvik.adoc
@@ -8,7 +8,7 @@ Denne versjonen av DCAT-AP-NO avviker BRegDCAT-AP på følgende måter:
 |===
 |*Klasse-/egenskapsnavn*|*URI for klassen/egenskapen*|*Avvik*|*Forklaring*
 |Datasett: begrep|dct:subject|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1
-|Datasett: følger|cpsv:follows|Endret fra valgfri til anbefalt|Denne erstatter anbefalt egenskap Datasett: skjermingshjemmel i DCAT-AP-NO v.1.1
+|Datasett: følger|cpsv:follows|Endret fra valgfri til anbefalt|Denne erstatter egenskap Datasett: skjermingshjemmel som var anbefalt i DCAT-AP-NO v.1.1
 |Datasett: tema|dcat:theme|Endret fra anbefalt til obligatorisk, dermed også kardinalitet|Allerede i DCAT-AP-NO v.1.1
 |Datasett: tilgangsnivå|dct:accessRights|Endret fra valgfri til anbefalt|Allerede i DCAT-AP-NO v.1.1
 |Datasett: utgiver|dct:publisher|Endret fra anbefalt til obligatorisk, dermed også kardinalitet|Allerede i DCAT-AP-NO v.1.1

--- a/docs/06_Oversikt_over_klasser.adoc
+++ b/docs/06_Oversikt_over_klasser.adoc
@@ -47,31 +47,6 @@
 | Status | Obligatorisk
 |===
 
-=== Offentlig organisasjon [[klasse-offentlig-organisasjon]]
-
-[cols="30s,70d"]
-|===
-| Engelsk navn | Public organisation
-| Beskrivelse | Brukes til å representere en aktør som er ansvarlig for å yte en offentlig tjeneste.
-| URI | cv:PublicOrganization
-| Referanse | https://joinup.ec.europa.eu/solution/core-public-service-vocabulary
-http://www.w3.org/TR/vocab-org/; https://www.w3.org/TR/vocab-org/
-| Status | Obligatorisk
-|===
-
-=== Offentlig tjeneste [[klasse-offentlig-tjeneste]]
-
-[cols="30s,70d"]
-|===
-| Engelsk navn | Public service
-| Beskrivelse | Brukes til å representere en offentlig tjeneste, bl.a. tjeneste som skaper og/eller forvalter grunndataregistre/basisregistre eller oversikter over registre (såkalt «register over register»).
-| URI | cpsv:PublicService
-| Referanse | https://joinup.ec.europa.eu/solution/core-public-service-vocabulary
-| Status | Obligatorisk
-|Kommentar| "Public Registry Service" er det engelske navnet til denne klassen i BRegDCAT-AP.
-|Eksempel| Tjenester som tilbys av offentlige forvaltningsorganer eller andre organisasjoner på deres vegne, for lagring og tilgjengeliggjøring av basis informasjon om autoritative data som personer, organisasjoner, kjøretøy, førerkort, bygninger, lokasjoner og veier.
-|===
-
 === Tema [[klasse-tema]]
 
 [cols="30s,70d"]
@@ -107,7 +82,6 @@ http://www.w3.org/TR/vocab-org/; https://www.w3.org/TR/vocab-org/
 |URI | dcat:Dataset
 |Referanse | https://www.w3.org/TR/vocab-dcat/#Class:Dataset
 | Status | Anbefalt
-| Kommentar| Denne klassen er p.t. obligatorisk i BRegDCAT-AP. ABR-teamet i ISA-programmet som har ansvaret for å ferdigstille BRegDCAT-AP har sagt at denne klassen kommer til å bli anbefalt.
 |===
 
 === Distribusjon [[klasse-distribusjon]]
@@ -130,6 +104,31 @@ http://www.w3.org/TR/vocab-org/; https://www.w3.org/TR/vocab-org/
 | URI | dct:LicenseDocument
 | Referanse | http://dublincore.org/documents/2012/06/14/dcmi-terms/?v=terms#LicenseDocument
 | Status | Anbefalt
+|===
+
+=== Offentlig organisasjon [[klasse-offentlig-organisasjon]]
+
+[cols="30s,70d"]
+|===
+| Engelsk navn | Public organisation
+| Beskrivelse | Brukes til å representere en aktør som er ansvarlig for å yte en offentlig tjeneste.
+| URI | cv:PublicOrganization
+| Referanse | https://joinup.ec.europa.eu/solution/core-public-service-vocabulary
+http://www.w3.org/TR/vocab-org/; https://www.w3.org/TR/vocab-org/
+| Status | Anbefalt
+|===
+
+=== Offentlig tjeneste [[klasse-offentlig-tjeneste]]
+
+[cols="30s,70d"]
+|===
+| Engelsk navn | Public service
+| Beskrivelse | Brukes til å representere en offentlig tjeneste, bl.a. tjeneste som skaper og/eller forvalter grunndataregistre/basisregistre eller oversikter over registre (såkalt «register over register»).
+| URI | cpsv:PublicService
+| Referanse | https://joinup.ec.europa.eu/solution/core-public-service-vocabulary
+| Status | Anbefalt
+|Kommentar| "Public Registry Service" er det engelske navnet til denne klassen i BRegDCAT-AP.
+|Eksempel| Tjenester som tilbys av offentlige forvaltningsorganer eller andre organisasjoner på deres vegne, for lagring og tilgjengeliggjøring av basis informasjon om autoritative data som personer, organisasjoner, kjøretøy, førerkort, bygninger, lokasjoner og veier.
 |===
 
 === Regel [[klasse-regel]]
@@ -257,6 +256,18 @@ http://www.w3.org/TR/vocab-org/; https://www.w3.org/TR/vocab-org/
 |===
 
 
+=== Relasjon [[klasse-relasjon]]
+
+[cols="30s,70d"]
+|===
+| Engelsk navn | Relationship
+| Beskrivelse | Brukes til å knytte tilleggsinformasjon til en relasjon mellom ressurser.
+| URI | dcat:Relationship
+| Referanse | https://www.w3.org/TR/vocab-dcat-2/#Class:Relationship
+| Status | Valgfri
+|===
+
+
 === Rettighetsutsagn [[klasse-rettighetsutsagn]]
 
 [cols="30s,70d"]
@@ -265,6 +276,19 @@ http://www.w3.org/TR/vocab-org/; https://www.w3.org/TR/vocab-org/
 | Beskrivelse | Brukes til å representere et utsagn om immaterielle rettigheter knyttet til en ressurs, et juridisk dokument som gir offisiell tillatelse til å gjøre noe med en ressurs, eller en uttalelse om tilgangsrettigheter.
 | URI | dct:RightsStatement
 | Referanse | http://dublincore.org/documents/dcmi-terms/#terms-RightsStatement
+| Status | Valgfri
+|===
+
+
+=== Rolle [[klasse-rolle]]
+
+[cols="30s,70d"]
+|===
+| Engelsk navn | Role
+| Beskrivelse | Brukes til å representere funksjonen til en ressurs eller aktør i relasjon til en annen ressurs.
+| URI | dcat:Role
+|Subklasse av|skos:Concept
+| Referanse | https://www.w3.org/TR/vocab-dcat-2/#Class:Role
 | Status | Valgfri
 |===
 
@@ -278,7 +302,6 @@ http://www.w3.org/TR/vocab-org/; https://www.w3.org/TR/vocab-org/
 | URI | spdx:Checksum
 | Referanse | http://spdx.org/rdf/terms#Checksum
 | Status | Valgfri
-| Kommentar | Norsk utvidelse. Denne klassen er ikke eksplisitt tatt med i BRegDCAT-AP, men den var med i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===
 
 === Språksystem [[klasse-spraksystem]]
@@ -336,5 +359,4 @@ http://www.w3.org/TR/vocab-org/; https://www.w3.org/TR/vocab-org/
 | URI | skos:Concept
 | Referanse | http://www.w3.org/TR/vocab-adms/#dcterms-type
 | Status | Valgfri
-| Kommentar | Norsk utvidelse. Denne klassen er ikke eksplisitt tatt med i BRegDCAT-AP, men den var med i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===

--- a/docs/22_Kontrollerte_vokabular.adoc
+++ b/docs/22_Kontrollerte_vokabular.adoc
@@ -53,7 +53,6 @@ Under følger en oversikt over kontrollerte vokabular som *skal* brukes (= oblig
 |Navn på vokabularet|Distribution availability vocabulary
 |URI til vokabularet|http://data.europa.eu/r5r/availability/[http://data.europa.eu/r5r/availability/]
 |Status|Obligatorisk
-|Kommentar|Denne er obligatorisk i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===
 
 === For egenskapen dct:creator

--- a/docs/22_Kontrollerte_vokabular.adoc
+++ b/docs/22_Kontrollerte_vokabular.adoc
@@ -131,6 +131,7 @@ Under følger en oversikt over kontrollerte vokabular som *skal* brukes (= oblig
 |Brukt i klasse|<<datasett-dekningsomrade, Datasett (`dcat:Dataset`)>>; <<katalog-dekningsomrade, Katalog (`dcat:Catalog`)>>; <<offentlig-organisasjon-dekningsområde, Offentlig organisasjon (`cv:PublicOrganization`)>>; <<offentlig-tjeneste-dekningsområde, Offentlig tjeneste (`cpsv:PublicService`)>>
 |Navn på vokabularet|Continents NAL, Countries NAL, Places NAL, GeoNames (GeoNames er obligatorisk i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på)
 |URI til vokabularet|http://publications.europa.eu/resource/dataset/continent[http://publications.europa.eu/resource/dataset/continent];
+http://publications.europa.eu/resource/dataset/country[http://publications.europa.eu/resource/dataset/country]; http://publications.europa.eu/resource/dataset/place[http://publications.europa.eu/resource/dataset/place]; http://sws.geonames.org/[http://sws.geonames.org/]
 |Status|Obligatorisk
 |===
 

--- a/docs/22_Kontrollerte_vokabular.adoc
+++ b/docs/22_Kontrollerte_vokabular.adoc
@@ -165,6 +165,7 @@ Under følger en oversikt over kontrollerte vokabular som *skal* brukes (= oblig
 |Brukt i klasse|<<datasett-tema, Datasett (`dcat:Dataset`)>>
 |Navn på vokabularet|EuroVoc; Data Theme Taxonomy NAL
 |URI til vokabularet|http://publications.europa.eu/resource/dataset/eurovoc[http://publications.europa.eu/resource/dataset/eurovoc];
+http://publications.europa.eu/resource/authority/datatheme[http://publications.europa.eu/resource/authority/datatheme]
 |Kommentar|https://psi.norge.no/los/struktur.html[Los] bør brukes i tillegg til EuroVoc og Data Theme fra EU.
 |Status|Obligatorisk
 |===

--- a/docs/Klasse_Aktor.adoc
+++ b/docs/Klasse_Aktor.adoc
@@ -15,7 +15,6 @@ enheten/virksomheten dersom den finnes i registeret, f.eks. `dct:publisher <\htt
 |Beskrivelse| Navn på aktøren. Denne egenskapen kan gjentas for ulike versjoner av navnet (som navnet på forskjellige språk).
 |Multiplisitet| 1..n
 |Status| Obligatorisk
-|Kommentar| Norsk utvidelse. Denne er ikke eksplisitt tatt med i BRegDCAT-AP, men var med i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===
 
 == Anbefalte egenskaper for klassen _Aktør_
@@ -30,7 +29,6 @@ enheten/virksomheten dersom den finnes i registeret, f.eks. `dct:publisher <\htt
 |Beskrivelse| Egenskap som angir organisasjonens identifikasjonsnummer, for eksempel i henhold til Enhetsregisterets organisasjonsnummer.
 |Multiplisitet| 0..1
 |Status| Anbefalt
-|Kommentar| Norsk utvidelse. Denne er ikke eksplisitt tatt med i BRegDCAT-AP, men var med i DCAT-AP-NO v.1.1 og allerede da som en norsk utvidelse.
 |===
 
 === Aktør: utgivertype [[aktor-utgivertype]]
@@ -43,5 +41,4 @@ enheten/virksomheten dersom den finnes i registeret, f.eks. `dct:publisher <\htt
 |Beskrivelse| Refererer til type aktør som gjør katalogen eller ressursen tilgjengelig.
 |Multiplisitet| 0..1
 |Status| Anbefalt
-|Kommentar| Norsk utvidelse. Denne er ikke eksplisitt tatt med i BRegDCAT-AP, men var med i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===

--- a/docs/Klasse_Datasett.adoc
+++ b/docs/Klasse_Datasett.adoc
@@ -295,7 +295,6 @@ der `provno:administrativeDecision` (vedtak), `provno:collectingFromThirdparty` 
 |Beskrivelse| Referanse til et annet datasett som dette datasettet er nødvendig for.
 |Multiplisitet| 0..n
 |Status| Valgfri
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den var med i DCAT-AP-NO v.1.1.
 |===
 
 === Datasett: er referert av [[datasett-er-referert-av]]
@@ -308,7 +307,6 @@ der `provno:administrativeDecision` (vedtak), `provno:collectingFromThirdparty` 
 |Beskrivelse| Referanse til et annet datasett som refererer til dette datasettet.
 |Multiplisitet| 0..n
 |Status| Valgfri
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den var med i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===
 
 === Datasett: er versjon av [[datasett-er-versjon-av]]
@@ -333,7 +331,6 @@ der `provno:administrativeDecision` (vedtak), `provno:collectingFromThirdparty` 
 |Beskrivelse| Referanse til et annet datasett som dette datasettet er ment å erstatte.
 |Multiplisitet| 0..n
 |Status| Valgfri
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den var med i DCAT-AP-NO v.1.1.
 |===
 
 === Datasett: erstattes av [[datasett-erstattes-av]]
@@ -346,7 +343,6 @@ der `provno:administrativeDecision` (vedtak), `provno:collectingFromThirdparty` 
 |Beskrivelse| Referanse til datasett som er ment å erstatte dette datasettet.
 |Multiplisitet| 0..n
 |Status| Valgfri
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den var med i DCAT-AP-NO v.1.1.
 |===
 
 === Datasett: frekvens [[datasett-frekvens]]
@@ -502,7 +498,6 @@ dqvno:isAuthoritative
 |Beskrivelse| Referanse til et annet datasett som er nødvendig for å bruke dette datasettet riktig. Eksempel: et datasett kan bruke kodeverdier som er definert i et annet datasett.
 |Multiplisitet| 0..n
 |Status| Valgfri
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den var med i DCAT-AP-NO v.1.1.
 |===
 
 === Datasett: kvalifisert navngivelse [[datasett-kvalifisert-navngivelse]]
@@ -575,7 +570,6 @@ dqvno:isAuthoritative
 |Beskrivelse| Referanse til andre datasett som det kan være nyttig for brukere å være oppmerksom på.
 |Multiplisitet| 0..n
 |Status| Valgfri
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den var med i DCAT-AP-NO v.1.1.
 |===
 
 === Datasett: relatert ressurs [[datasett-relatertressurs]]

--- a/docs/Klasse_Datasett.adoc
+++ b/docs/Klasse_Datasett.adoc
@@ -500,7 +500,7 @@ dqvno:isAuthoritative
 |Status| Valgfri
 |===
 
-=== Datasett: kvalifisert navngivelse [[datasett-kvalifisert-navngivelse]]
+=== Datasett: kvalifisert kreditering [[datasett-kvalifisert-kreditering]]
 
 [cols="30s,70d"]
 |===

--- a/docs/Klasse_Datasett.adoc
+++ b/docs/Klasse_Datasett.adoc
@@ -129,7 +129,7 @@ NOTE: Referanse til et begrep fra et datasett bør det være i samsvar med ev. i
 |Range|cpsv:Rule
 |Beskrivelse|Brukes til å referere til reglen som definerer den juridiske rammen for datasettet.
 |Multiplisitet|0..n
-|Status|Anefalt
+|Status|Anbefalt
 |Kommentar| Norsk utvidelse - Denne egenskapen er endret fra valgfri til anbefalt.
 |Eksempel a| [source]
 ----

--- a/docs/Klasse_Datatjeneste.adoc
+++ b/docs/Klasse_Datatjeneste.adoc
@@ -1,4 +1,3 @@
-
 = Datatjeneste [[datatjeneste]]
 
 Klassen _Datatjeneste_ er valgfri.

--- a/docs/Klasse_Datatjeneste.adoc
+++ b/docs/Klasse_Datatjeneste.adoc
@@ -43,6 +43,18 @@ Klassen _Datatjeneste_ er valgfri.
 
 == Anbefalte egenskaper for klassen _Datatjeneste_
 
+=== Datatjeneste: emneord [[datatjeneste-emneord]]
+
+[cols="30s,70d"]
+|===
+|Engelsk navn| keyword
+|URI| dcat:keyword
+|Range| rdfs:Literal
+|Beskrivelse| Inneholder emneord (eller tag) som beskriver datatjenesten.
+|Multiplisitet| 0..n
+|Status| Anbefalt
+|===
+
 === Datatjeneste: endepunktsbeskrivelse [[datatjeneste-endepunktsbeskrivelse]]
 
 [cols="30s,70d"]
@@ -51,6 +63,31 @@ Klassen _Datatjeneste_ er valgfri.
 |URI| dcat:endpointDescription
 |Range| rdfs:Resource
 |Beskrivelse| Denne egenskapen inneholder en beskrivelse av tjenestene som er tilgjengelige via endepunktene, inkludert deres operasjoner, parametere osv. Egenskapen gir spesifikke detaljer om de faktiske endepunkt-instansene, mens dct:conformsTo brukes til å indikere den generelle standarden eller spesifikasjonen som endepunktene implementerer.
+|Multiplisitet| 0..n
+|Status| Anbefalt
+|===
+
+
+=== Datatjeneste: kontaktpunkt [[datatjeneste-kontaktpunkt]]
+
+[cols="30s,70d"]
+|===
+|Engelsk navn| contact point
+|URI| dcat:contactPoint
+|Range| vcard:Kind
+|Beskrivelse| Referanse til kontaktpunktsobjekt med kontaktopplysninger. Disse kan brukes til å sende kommentarer om datatjenesten.
+|Multiplisitet| 0..n
+|Status| Anbefalt
+|===
+
+=== Datatjeneste: tema [[datatjeneste-tema]]
+
+[cols="30s,70d"]
+|===
+|Engelsk navn| theme
+|URI| dcat:theme
+|Range| skos:Concept
+|Beskrivelse| Referanse til et hovedtema for datatjenesten. En datatjeneste kan assosieres med flere tema.
 |Multiplisitet| 0..n
 |Status| Anbefalt
 |===
@@ -67,6 +104,19 @@ Klassen _Datatjeneste_ er valgfri.
 |Status| Anbefalt
 |===
 
+=== Datatjeneste: utgiver [[datatjeneste-utgiver]]
+
+[cols="30s,70d"]
+|===
+|Engelsk navn| publisher
+|URI| dct:publisher
+|Range| foaf:Agent
+|Beskrivelse| Referanse til en aktør (organisasjon) som er ansvarlig for å gjøre datatjenesten tilgjengelig. Bør være autoritativ URI for aktøren, f.eks. dct:publisher <https://data.brreg.no/enhetsregisteret/api/enheter/974760673>.
+|Multiplisitet| 0..1
+|Status| Anbefalt
+|===
+
+
 == Valgfrie egenskaper for klassen _Datatjeneste_
 
 === Datatjeneste: beskrivelse [[datatjeneste-beskrivelse]]
@@ -76,6 +126,17 @@ Klassen _Datatjeneste_ er valgfri.
 |URI| dct:description
 |Range| rdfs:Literal
 |Beskrivelse| Inneholder en fritekstbeskrivelse av datatjenesten. Egenskapen bør gjentas for parallelle språkversjoner.
+|Multiplisitet| 0..n
+|Status| Valgfri
+|===
+
+=== Datatjeneste: dokumentasjon [[datatjeneste-dokumentasjon]]
+[cols="30s,70d"]
+|===
+|Engelsk navn| page (documentation)
+|URI| foaf:page
+|Range| foaf:Document
+|Beskrivelse| Referanse til en side eller et dokument som beskriver datatjenesten.
 |Multiplisitet| 0..n
 |Status| Valgfri
 |===
@@ -102,6 +163,17 @@ Klassen _Datatjeneste_ er valgfri.
 |Status| Valgfri
 |===
 
+=== Datatjeneste: landingsside [[datatjeneste-landingsside]]
+[cols="30s,70d"]
+|===
+|Engelsk navn| landing page
+|URI| dcat:landingPage
+|Range| foaf:Document
+|Beskrivelse| Referanse til nettside som gir tilgang til datatjenesten, dens distribusjoner og/eller tilleggsinformasjon. Intensjonen er å peke til en landingsside hos den opprinnelige datautgiveren.
+|Kardinalitet| 0..1
+|Status| Valgfri
+|===
+
 === Datatjeneste: lisens [[datatjeneste-lisens]]
 [cols="30s,70d"]
 |===
@@ -120,6 +192,17 @@ Klassen _Datatjeneste_ er valgfri.
 |URI| dct:accessRights
 |Range| dct:RightsStatement
 |Beskrivelse| Denne egenskapen KAN inkludere informasjon angående tilgang eller begrensninger basert på personvern, sikkerhet eller andre retningslinjer.
+|Multiplisitet| 0..1
+|Status| Valgfri
+|===
+
+=== Datatjeneste: type [[datatjeneste-type]]
+[cols="30s,70d"]
+|===
+|Engelsk navn| type
+|URI| dct:type
+|Range| skos:Concept
+|Beskrivelse| Referanse til et begrep som identifiserer datatjenestens type.
 |Multiplisitet| 0..1
 |Status| Valgfri
 |===

--- a/docs/Klasse_Distribusjon.adoc
+++ b/docs/Klasse_Distribusjon.adoc
@@ -116,7 +116,6 @@ Klassen _Distribusjon_ er anbefalt.
 |Beskrivelse| Refererer til den minste geografiske oppløsningen for en datasettdistribusjon målt i meter.
 |Multiplisitet| 0..n
 |Status| Valgfri
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===
 
 === Distribusjon: i samsvar med [[distribusjon-i-samsvar-med]]
@@ -129,7 +128,6 @@ Klassen _Distribusjon_ er anbefalt.
 |Beskrivelse| Referanse til et etablert skjema som distribusjonen er i samsvar med.
 |Multiplisitet| 0..n
 |Status| Valgfri
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den var med i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===
 
 === Distribusjon: komprimeringsformat [[distribusjon-komprimeringsformat]]
@@ -175,7 +173,6 @@ Klassen _Distribusjon_ er anbefalt.
 |Beskrivelse| Refererer til formatet til filen der en eller flere datafiler er gruppert sammen, f.eks. for å gjøre det mulig å laste ned et sett relaterte filer.
 |Multiplisitet| 0..1
 |Status| Valgfri
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===
 
 === Distribusjon: policy [[distribusjon-policy]]
@@ -187,7 +184,6 @@ Klassen _Distribusjon_ er anbefalt.
 |Beskrivelse| Refererer til policyen som uttrykker rettighetene knyttet til distribusjonen hvis de bruker ODRL-vokabularet.
 |Multiplisitet| 0..1
 |Status| Valgfri
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===
 
 === Distribusjon: rettigheter [[distribusjon-rettigheter]]
@@ -200,7 +196,6 @@ Klassen _Distribusjon_ er anbefalt.
 |Beskrivelse| Viser til en uttalelse som angir rettigheter knyttet til distribusjonen.
 |Multiplisitet| 0..1
 |Status| Valgfri
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den var med i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===
 
 === Distribusjon: sjekksum [[distribusjon-sjekksum]]
@@ -237,7 +232,6 @@ Klassen _Distribusjon_ er anbefalt.
 |Beskrivelse| Distribusjonens modenhet. Må ha en av verdiene `Completed`, `Deprecated`, `Under Development`, `Withdrawn`.
 |Multiplisitet| 0..1
 |Status| Valgfri
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den var med i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===
 
 === Distribusjon: tidsromsoppløsning
@@ -250,7 +244,6 @@ Klassen _Distribusjon_ er anbefalt.
 |Beskrivelse| Refererer til minste tidsrommet som kan utledes fra datasett-distribusjonen ("resolvable in the dataset distribution").
 |Multiplisitet| 0..n
 |Status| Valgfri
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===
 
 === Distribusjon: tilgangstjeneste [[distribusjon-tilganstjeneste]]
@@ -275,7 +268,6 @@ Klassen _Distribusjon_ er anbefalt.
 |Beskrivelse| Navn på distribusjonen.
 |Multiplisitet| 0..n
 |Status| Valgfri
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den var med i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===
 
 === Distribusjon: utgivelsesdato [[distribusjon-utgivelsesdato]]

--- a/docs/Klasse_Identifikator.adoc
+++ b/docs/Klasse_Identifikator.adoc
@@ -14,5 +14,4 @@ Klassen _Identifikator_ er valgfri.
 |Beskrivelse| Identifikator i henhold til nevnte identifikatorskjema.
 |Multiplisitet| 1..1
 |Status| Obligatorisk
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===

--- a/docs/Klasse_Katalog.adoc
+++ b/docs/Klasse_Katalog.adoc
@@ -71,7 +71,7 @@ Klassen _Katalog_ er obligatorisk.
 
 [cols="30s,70d"]
 |===
-|Engelsk navn| spatial/geographic
+|Engelsk navn| spatial coverage
 |URI| dct:spatial
 |Range| dct:Location
 |Beskrivelse| Referanse til et geografisk område som er dekket av katalogen.
@@ -155,7 +155,7 @@ Klassen _Katalog_ er obligatorisk.
 
 [cols="30s,70d"]
 |===
-|Engelsk navn| themes
+|Engelsk navn| theme taxonomy
 |URI| dcat:themeTaxonomy
 |Range| skos:ConceptScheme
 |Beskrivelse| Refererer til et kunnskapsorganiseringssystem (KOS) som er brukt for å klassifisere katalogens datasett.
@@ -199,7 +199,6 @@ Klassen _Katalog_ er obligatorisk.
 |Beskrivelse| Referanse til en beslektet katalog som denne katalogen fysisk eller logisk er inkludert i.
 |Multiplisitet| 0..1
 |Status| Valgfri
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den var med i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===
 
 === Katalog: har del [[katalog-har-del]]
@@ -212,7 +211,6 @@ Klassen _Katalog_ er obligatorisk.
 |Beskrivelse| Referanse til en beslektet katalog som er en del av den beskrevne katalogen.
 |Multiplisitet| 0..n
 |Status| Valgfri
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den var med i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===
 
 === Katalog: katalog [[katalog-katalog]]

--- a/docs/Klasse_Katalog.adoc
+++ b/docs/Klasse_Katalog.adoc
@@ -1,4 +1,3 @@
-
 = Katalog [[katalog]]
 
 Klassen _Katalog_ er obligatorisk.

--- a/docs/Klasse_Lisensdokument.adoc
+++ b/docs/Klasse_Lisensdokument.adoc
@@ -14,5 +14,4 @@ Klassen _Lisensdokument_ er anbefalt.
 |Beskrivelse| Refererer til type lisens, f.eks. som indikerer "fri bruk" (Public Domain) eller "royalties kreves". Egenskapen kan gjentas i de tilfellene der flere lisenstyper gjelder for et lisensdokument.
 |Multiplisitet| 0..n
 |Status| Anbefalt
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den var med i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===

--- a/docs/Klasse_Offentlig_organisasjon.adoc
+++ b/docs/Klasse_Offentlig_organisasjon.adoc
@@ -1,6 +1,6 @@
 = Offentlig organisasjon [[offentlig-organisasjon]]
 
-Klassen _Offentlig organisasjon_ er obligatorisk.
+Klassen _Offentlig organisasjon_ er anbefalt.
 
 == Obligatoriske egenskaper for klassen _Offentlig organisasjon_
 

--- a/docs/Klasse_Offentlig_tjeneste.adoc
+++ b/docs/Klasse_Offentlig_tjeneste.adoc
@@ -1,6 +1,6 @@
 = Offentlig tjeneste [[offentlig-tjeneste]]
 
-Klassen _Offentlig tjeneste_ er obligatorisk.
+Klassen _Offentlig tjeneste_ er anbefalt.
 
 == Obligatoriske egenskaper for klassen _Offentlig tjeneste_
 

--- a/docs/Klasse_Regulativ_ressurs.adoc
+++ b/docs/Klasse_Regulativ_ressurs.adoc
@@ -49,10 +49,11 @@ Klassen _Regulativ ressurs_ er anbefalt.
 |===
 |Engelsk navn|reference
 |URI|rdfs:seeAlso
-|Range|xsd:anyURI
+|Range|rdfs:Resource
 |Beskrivelse|Brukes til å oppgi referanse til regelverksressurs.
 |Multiplisitet|0..n
 |Status|Anbefalt
+|Kommentar|For referanse til Lovdata bør ELI-URI brukes, se https://lovdata.no/eli/[beskrivelsen hos Lovdata].
 |===
 
 == Valgfrie egenskaper for klassen _Regulativ ressurs_

--- a/docs/Klasse_Regulativ_ressurs.adoc
+++ b/docs/Klasse_Regulativ_ressurs.adoc
@@ -53,7 +53,6 @@ Klassen _Regulativ ressurs_ er anbefalt.
 |Beskrivelse|Brukes til å oppgi referanse til regelverksressurs.
 |Multiplisitet|0..n
 |Status|Anbefalt
-|Kommentar|Norsk utvidelse, for å kunne oppgi referanse til en regulativ ressurs.
 |===
 
 == Valgfrie egenskaper for klassen _Regulativ ressurs_

--- a/docs/Klasse_Relasjoner.adoc
+++ b/docs/Klasse_Relasjoner.adoc
@@ -14,7 +14,6 @@ Klassen _Relasjon_ er valgfri.
 |Beskrivelse| Refererer til ressursen som har relasjon til kilderessursen.
 |Multiplisitet| 1..n
 |Status| Obligatorisk
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===
 
 === Relasjon: rolle [[relasjon-rolle]]
@@ -27,5 +26,4 @@ Klassen _Relasjon_ er valgfri.
 |Beskrivelse| Refererer til funksjonen til en enhet eller aktør i forhold til en annen enhet eller ressurs.
 |Multiplisitet| 1..n
 |Status| Obligatorisk
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===

--- a/docs/Klasse_Sjekksum.adoc
+++ b/docs/Klasse_Sjekksum.adoc
@@ -14,7 +14,6 @@ Klassen _Sjekksum_ er valgfri.
 |Beskrivelse| Identifiserer algoritmen som er brukt til å produsere sjekksum. For øyeblikket er SHA-1 den eneste algoritmen som er støttet. Det er forventet støtte for andre algoritmer på et senere tidspunkt.
 |Multiplisitet| 1..1
 |Status| Obligatorisk
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den var med i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===
 
 === Sjekksum: sjekksumverdi [[sjekksum-sjekksumverdi]]
@@ -27,5 +26,4 @@ Klassen _Sjekksum_ er valgfri.
 |Beskrivelse| Denne egenskapen brukes til å oppgi en heksadesimal-kodet verdi med små bokstaver, produsert ved hjelp av en spesifikk algoritme.
 |Multiplisitet| 1..1
 |Status| Obligatorisk
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den var med i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===

--- a/docs/Klasse_Tema.adoc
+++ b/docs/Klasse_Tema.adoc
@@ -14,5 +14,4 @@ Klassen _Tema_ er obligatorisk.
 |Beskrivelse| Foretrukket tittel for kategorien. Kan gjentas for parallelle språkversjoner av etiketten.
 |Multiplisitet| 1..n
 |Status| Obligatorisk
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den var med i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===

--- a/docs/Klasse_Tematisk_skjema.adoc
+++ b/docs/Klasse_Tematisk_skjema.adoc
@@ -14,5 +14,4 @@ Klassen _Tematisk skjema_ er obligatorisk.
 |Beskrivelse| Navn på det tematiske skjemaet. Kan gjentas for forskjellige versjoner av navnet
 |Multiplisitet| 1..n
 |Status| Obligatorisk
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den var med i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===

--- a/docs/Klasse_Tidsrom.adoc
+++ b/docs/Klasse_Tidsrom.adoc
@@ -14,7 +14,6 @@ Klassen _Tidsrom_ er valgfri.
 |Beskrivelse| Definerer slutten på tidsrommet.
 |Multiplisitet| 0..1
 |Status| Anbefalt
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den var med i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===
 
 NOTE: Vær oppmerksom på at selv om begge egenskapene anbefales, må en av de to være til stede for hver forekomst av klassen `dct:PeriodOfTime` (hvis klassen er brukt). Starten av perioden bør forstås som starten på datoen, timen, minuttet (f.eks. starter ved midnatt på begynnelsen av dagen hvis verdien er en dato). Slutten av perioden skal forstås som slutten av datoen, timen, minuttet (f.eks. slutter ved midnatt på slutten av dagen hvis verdien er en dato).
@@ -28,7 +27,6 @@ NOTE: Vær oppmerksom på at selv om begge egenskapene anbefales, må en av de t
 |Beskrivelse| Definerer starten på tidsrommet.
 |Multiplisitet| 0..1
 |Status| Anbefalt
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den var med i DCAT-AP-NO v.1.1 og i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===
 
 == Valgfrie egenskaper for klassen _Tidsrom_
@@ -42,7 +40,6 @@ NOTE: Vær oppmerksom på at selv om begge egenskapene anbefales, må en av de t
 |Beskrivelse| Definerer begynnelsen på et tidsrommet eller intervall.
 |Multiplisitet| 0..1
 |Status| Valgfritt
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===
 
 === Tidsrom: slutt [[tidsrom-slutt]]
@@ -54,5 +51,4 @@ NOTE: Vær oppmerksom på at selv om begge egenskapene anbefales, må en av de t
 |Beskrivelse| Definerer slutten på et tidsrom eller intervall.
 |Multiplisitet| 0..1
 |Status| Valgfritt
-|Kommentar| Norsk utvidelse - Denne egenskapen er ikke eksplisitt tatt med i BRegDCAT-AP, men den er i DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på.
 |===

--- a/docs/XX_endringslogg.adoc
+++ b/docs/XX_endringslogg.adoc
@@ -24,6 +24,7 @@ Tabellen under oppsummerer endringer som følger av ny versjon av BRegDCAT-AP (v
 |Datasett: erstatter|dct:replaces|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
 |Datasett: erstattes av|dct:isReplacedBy|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
 |Datasett: krever|dct:requires|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Datasett: kvalifisert kreditering | prov:qualifiedAttribution | Det norske navnet er endret fra "kvalifisert navngivelse" til "kvalifisert kreditering" | Gjenspeiler bedre "qualified attribution"
 |Datasett: refererer til|dct:references|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
 |Datatjeneste: dokumentasjon|foaf:page|Ny egenskap|Dette i henhold til BRegDCAT-AP v.1.05
 |Datatjeneste: emneord|dcat:keyword|Ny egenskap|Dette i henhold til BRegDCAT-AP v.1.05

--- a/docs/XX_endringslogg.adoc
+++ b/docs/XX_endringslogg.adoc
@@ -1,4 +1,3 @@
-
 = Endringslogg
 
 Tabellen under gir en oversikt over endringene i klasser og egenskaper, fra v.1.1 til denne versjonen av DCAT-AP-NO. Redaksjonelle justeringer av tekster (inkl. tekstlige beskrivelser, kommentarer og eksempler) er ikke tatt med i oversikten.

--- a/docs/XX_endringslogg.adoc
+++ b/docs/XX_endringslogg.adoc
@@ -20,12 +20,15 @@ Tabellen under gir en oversikt over endringene i klasser og egenskaper, fra v.1.
 |Datasett: produsent |dct:creator |Norsk navn endret fra `Datasett: skaper` til `Datasett: produsent` |Bedre dekkende navn
 |Datasett: produsent |dct:creator |Range er endret fra `rdfs:Resource` til `foaf:Agent` |Dette i henhold til BRegDCAT-AP
 |Datasett: proveniensbeskrivelse |dct:provenance |Norsk navn endret fra `Datasett: opphav` til `Datasett: proveniensbeskrivelse` |Bedre dekkende navn
+|Datasett: proveniensbeskrivelse |dct:provenance |Kardinalitet endret fra `0..1` til `0..n` |Dette i henhold til BRegDCAT-AP
 |Datasett: refererer til |dct:references |Range endret fra `dcat:Dataset` til `rdfs:Resource` |Dette i henhold til BRegDCAT-AP
 |[.line-through]#Datasett: skjermingshjemmel# |[.line-through]#dcatno:accessRightsComment# |Fjernet. Erstattes med `Datasett: følger (cpsv:follows)` |Unødvendig med dette norske avvik
+|Datasett: tema|dcat:theme|Range endret fra `dcat:theme, subproperty of dct:subject` til `dcat:them`|Dette i henhold til BRegDCAT-AP
 |Datasett: tidsrom |dct:temporal |Endret fra valgfri til anbefalt |Dette i henhold til BRegDCAT-AP
 |Datasett: tidsromsoppløsning |dcat:temporalResolution |Ny egenskap |Dette i henhold til BRegDCAT-AP
 |Datasett: utgivelsesdato |dct:issued |Range endret fra `rdfs:Literal typed as xsd:dateTime` til `rdfs:Literal typed as xsd:date or xsd:dateTime` |Dette i henhold til BRegDCAT-AP
 |Datatjeneste |dcat:DataService |Hele klassen er ny  |Dette i henhold til BRegDCAT-AP
+|Distribusjon: format|dct:format|Range endret fra `dct:MediaTypeOrExtent` til `dct:format`|Dette i henhold til BRegDCAT-AP
 |Distribusjon: geografisk oppløsning |dcat:spatialResolutionInMeters |Ny egenskap |Dette i henhold til BRegDCAT-AP
 |Distribusjon: i samsvar med |dct:conformsTo |Norsk navn endret fra `Distribusjon: samsvarer med` til `Distribusjon: i samsvar med` |
 |Distribusjon: komprimeringsformat |dcat:compressFormat |Ny egenskap |Dette i henhold til BRegDCAT-AP
@@ -35,9 +38,11 @@ Tabellen under gir en oversikt over endringene i klasser og egenskaper, fra v.1.
 |Distribusjon: tidsromsoppløsning |dcat:temporalResolution |Ny egenskap |Dette i henhold til BRegDCAT-AP
 |Distribusjon: tilgangstjeneste |dcat:accessService |Ny egenskap |Dette i henhold til BRegDCAT-AP
 |Distribusjon: tilgjengelighet |dcatap:availability |Ny egenskap |Dette i henhold til BRegDCAT-AP
-|Identifikator: notasjon |skos:notation |Ny egenskap |Dette i henhold til DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
+|Identifikator: notasjon |skos:notation |Ny egenskap |Dette i henhold til BRegDCAT-AP
+|Katalog: datasett|dcat:dataset|Endret fra obligatorisk til anbefalt|Dette i henhold til BRegDCAT-AP
 |Katalog: datatjeneste|dcat:service|Ny egenskap|Dette i henhold til BRegDCAT-AP
 |Katalog: dekningsområde|dct:spatial|Endret fra valgfri til anbefalt|Dette i henhold til BRegDCAT-AP
+|Katalog: frekvens|dct:accrualPeriodicity|Ny egenskap|Dette i henhold til BRegDCAT-AP
 |Katalog: identifikator|dct:identifier|Ny egenskap|Dette i henhold til BRegDCAT-AP
 |Katalog: katalog|dcat:catalog|Ny egenskap|Dette i henhold til BRegDCAT-AP
 |Katalog: produsent|dct:creator|Ny egenskap|Dette i henhold til BRegDCAT-AP
@@ -48,11 +53,11 @@ dct:provenance|Ny egenskap|Dette i henhold til BRegDCAT-AP
 |Katalogpost: i samsvar med |dct:conformsTo |Range er endret fra `rdfs:Resource` til `dct:Standard` |Dette i henhold til BRegDCAT-AP
 |Katalogpost: kilde |dct:source |Multiplisitet er endret fra `0..n` til `0..1` |Dette i henhold til BRegDCAT-AP
 |Katalogpost: primærtema |foaf:primaryTopic |Range er endret fra `dcat:Dataset` til `dcat:Dataset or dcat:Dataservice or dcat:Catalog` |Dette i henhold til BRegDCAT-AP
-|Katalogpost: status |adms:status |Norsk navn er endret fra `Katalogpost: endringstype` til `Katalogpost: status' |
+|Katalogpost: status |adms:status |Norsk navn er endret fra `Katalogpost: endringstype` til `Katalogpost: status' |Bedre dekkende navn
 |Lisensdokument: lisenstype |dct:type |Multiplisitet endret fra `0..1` til `0..n` |Dette i henhold til BRegDCAT-AP
-|Lokasjon: geometri |locn:geometry |Ny egenskap |Dette i henhold til DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Lokasjon: område |dcat:bbox |Ny egenskap |Dette i henhold til DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Lokasjon: senterpunkt |dcat:centroid |Ny egenskap |Dette i henhold til DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
+|Lokasjon: geometri |locn:geometry |Ny egenskap |Dette i henhold tilBRegDCAT-AP
+|Lokasjon: område |dcat:bbox |Ny egenskap |Dette i henhold tilBRegDCAT-AP
+|Lokasjon: senterpunkt |dcat:centroid |Ny egenskap |Dette i henhold tilBRegDCAT-AP
 |Medietype|dct:MediaType|Range endret fra `dct:MediaTypeOrExtent` til `dct:MediaType` |Dette i henhold til BRegDCAT-AP
 |Medietype|dct:MediaType|Norsk navn endret fra `Mediatype eller omfang` til `Medietype`|Bedre dekkende navn
 |Offentlig organisasjon|cv:PublicOrganization|Hele klassen er ny|Dette i henhold til BRegDCAT-AP
@@ -61,12 +66,14 @@ dct:provenance|Ny egenskap|Dette i henhold til BRegDCAT-AP
 |Proveniensbeskrivelse|dct:ProvenanceStatement|Range endret fra `skos:Concept` til `dct:ProvenanceStatement`|Dette i henhold til BRegDCAT-AP
 |Regel|cpsv:Rule |Hele klassen er ny |Dette i henhold til BRegDCAT-AP
 |Regulativ ressurs |eli:LegalResource |Hele klassen er ny  |Dette i henhold til BRegDCAT-AP
-|Relasjon: relasjon |dct:relation |Ny egenskap |Dette i henhold til DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Relasjon: rolle |dcat:hadRole |Ny egenskap |Dette i henhold til DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
+|Relasjon|dcat:Relationship|Hele klassen er ny |Dette i henhold til BRegDCAT-AP
+|Rolle|dcat:Role|Hele klassen er ny |Dette i henhold til BRegDCAT-AP
 |Tema|skos:Concept|Norsk navn endret fra `Kategori` til `Tema`|Bedre dekkende navn
 |Tema|skos:Concept|Range endret fra `SKOS:Concept` til `skos:Concept`|Skrivefeil i DCAT-AP-NO v.1.1
 |Tematisk skjema|skos:ConceptScheme|Norsk navn endret fra `Kategoriskjema` til `Tematisk skjema`|Bedre dekkende navn
 |Tematisk skjema|skos:ConceptScheme|Range endret fra `SKOS:ConceptScheme` til `skos:ConceptScheme`|Skrivefeil i DCAT-AP-NO v.1.1
-|Tidsrom: begynnelse |time:hasBeginning |Ny egenskap |Dette i henhold til DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
-|Tidsrom: slutt |time:hasEnd |Ny egenskap |Dette i henhold til DCAT-AP v.2.0.0 som BRegDCAT-AP er basert på
+|Tidsrom: begynnelse |time:hasBeginning |Ny egenskap |Dette i henhold tilBRegDCAT-AP
+|Tidsrom: slutt |time:hasEnd |Ny egenskap |Dette i henhold til BRegDCAT-AP
+|Tidsrom: sluttdato/tid|dcat:endDate|Endret fra valgfri til anbefalt|Dette i henhold til BRegDCAT-AP
+|Tidsrom: startdato/tid|dcat:startDate|Endret fra valgfri til anbefalt|Dette i henhold til BRegDCAT-AP
 |===

--- a/docs/XX_endringslogg.adoc
+++ b/docs/XX_endringslogg.adoc
@@ -79,7 +79,7 @@ Tabellen under gir en oversikt over endringene i klasser og egenskaper, fra v.1.
 |Datasett: har del |dct:hasPart |Ny egenskap |Dette i henhold til BRegDCAT-AP
 |Datasett: har kvalitetsnote |dqv:hasQualityAnnotation |Ny egenskap |Dette i henhold til BRegDCAT-AP
 |Datasett: har kvantifiserbart måleresultat |dqv:hasQualityMeasurement |Ny egenskap |Dette i henhold til BRegDCAT-AP
-|Datasett: kvalifisert navngivelse |prov:qualifiedAttribution |Ny egenskap |Dette i henhold til BRegDCAT-AP
+|Datasett: kvalifisert kreditering |prov:qualifiedAttribution |Ny egenskap |Dette i henhold til BRegDCAT-AP
 |Datasett: kvalifisert relasjon |dcat:qualifiedRelation |Ny egenskap |Dette i henhold til BRegDCAT-AP
 |Datasett: produsent |dct:creator |Norsk navn endret fra `Datasett: skaper` til `Datasett: produsent` |Bedre dekkende navn
 |Datasett: produsent |dct:creator |Range er endret fra `rdfs:Resource` til `foaf:Agent` |Dette i henhold til BRegDCAT-AP

--- a/docs/XX_endringslogg.adoc
+++ b/docs/XX_endringslogg.adoc
@@ -1,5 +1,69 @@
 = Endringslogg
 
+== Endringer fra høringsutkastet datert 2. juni 2020, til denne versjonen [[endringer-høringsutkastet]]
+
+Etter at høringsutkastet ble publisert 2. juni 2020, er det blitt oppdateringer i EU sin BRegDCAT-AP som DCAT-AP-NO er basert på. Den oppdaterte versjonen av BRegDCAT-AP (v.1.05) dekker norske behov betydelig bedre, slik at de aller fleste norske utvidelsene ikke lenger trenger å være norske utvidelser. Høringsutkastet er derfor også blitt oppdatert.
+
+Tabellen under oppsummerer endringer som følger av ny versjon av BRegDCAT-AP (v.1.05).
+
+[cols="1,1,2,2"]
+|===
+|*Klasse-/egenskapsnavn*|*URI for klassen/egenskapen*|*Endring*|*Forklaring*
+|Datasett|dcat:Dataset|Tatt bort kommentar om at klassen var obligatorisk, men skulle vært anbefalt|Er nå anbefalt i BRegDCAT-AP v.1.05
+|Offentlig organisasjon|cv:PublicOrganization|Endret fra obligatorisk til anbefalt|Dette i henhold til BRegDCAT-AP v.1.05
+|Offentlig tjeneste|cpsv:PublicService|Endret fra obligatorisk til anbefalt|Dette i henhold til BRegDCAT-AP v.1.05
+|Relasjon|dcat:Relationship|Eksplisitt tatt med i oversikt over valgfrie klasser|Dette i henhold til BRegDCAT-AP v.1.05
+|Rolle|dcat:Role|Eksplisitt tatt med i oversikt over valgfrie klasser|Dette i henhold til BRegDCAT-AP v.1.05
+|Sjekksum|spdx:Checksum|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Utgivertype|skos:Concept|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Aktør: navn|foaf:name|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Aktør: organisasjonsidentifikator|dct:identifier|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Aktør: utgivertype|dct:type|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Datasett: er påkrevd av|dct:isRequiredBy|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Datasett: er referert av|dct:isReferencedBy|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Datasett: erstatter|dct:replaces|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Datasett: erstattes av|dct:isReplacedBy|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Datasett: krever|dct:requires|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Datasett: refererer til|dct:references|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Datatjeneste: dokumentasjon|foaf:page|Ny egenskap|Dette i henhold til BRegDCAT-AP v.1.05
+|Datatjeneste: emneord|dcat:keyword|Ny egenskap|Dette i henhold til BRegDCAT-AP v.1.05
+|Datatjeneste: kontaktpunkt|dcat:contactPoint|Ny egenskap|Dette i henhold til BRegDCAT-AP v.1.05
+|Datatjeneste: landingsside|dcat:landingPage|Ny egenskap|Dette i henhold til BRegDCAT-AP v.1.05
+|Datatjeneste: tema|dcat:theme|Ny egenskap|Dette i henhold til BRegDCAT-AP v.1.05
+|Datatjeneste: type|dct:type|Ny egenskap|Dette i henhold til BRegDCAT-AP v.1.05
+|Datatjeneste: utgiver|dct:publisher|Ny egenskap|Dette i henhold til BRegDCAT-AP v.1.05
+|Distribusjon: geografisk oppløsning|dcat:spatialResolutionInMeters|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Distribusjon: i samsvar med|dct:conformsTo|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Distribusjon: pakkeformat|dcat:packageFormat|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Distribusjon: policy|odrl:hasPolicy|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Distribusjon: rettigheter|dct:rights|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Distribusjon: status|adms:status|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Distribusjon: tidsromsoppløsning|dcat:temporalResolution|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Distribusjon: tittel|dct:title|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Identifikator: notasjon|skos:notation|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Katalog: dekningsområde|dct:spatial|Engelsk navn endret fra `spatial/geographic` til `spatial coverage`|Dette i henhold til BRegDCAT-AP v.1.05
+|Katalog: er del av|dct:isPartOf|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Katalog: har del|dct:hasPart|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Katalog: temaer|dcat:themeTaxonomy|Engelsk navn endret fra ` themes` til ` theme taxonomy`|Dette i henhold til BRegDCAT-AP v.1.05
+|Lisensdokument: lisenstype|dct:type|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Regulativ ressurs: referanse|rdfs:seeAlso|Tatt bort kommentar om norsk utvidelse.|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Regulativ ressurs: referanse|rdfs:seeAlso|Range endret fra `xsd:anyURI` til `rdfs:Resource`. Føyet til kommentar om å bruke ELI-URI der relevant.|Range endret, i henhold til BRegDCAT-AP v.1.05
+|Relasjon: relasjon|dct:relation|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Relasjon: rolle|dcat:hadRole|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Sjekksum: algoritme|spdx:algorithm|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Sjekksum: sjekksumverdi|spdx:checksumValue|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Tema: foretrukket tittel|skos:prefLabel|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Tematisk skjema: tittel|dct:title|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Tidsrom: begynnelse|time:hasBeginning|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Tidsrom: slutt|time:hasEnd|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Tidsrom: sluttdato/tid|dcat:endDate|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|Tidsrom: startdato/tid|dcat:startDate|Tatt bort kommentar om norsk utvidelse|Er nå eksplisitt med i BRegDCAT-AP v.1.05
+|===
+
+
+
+== Endringer fra versjon 1.1 til denne versjonen
+
 Tabellen under gir en oversikt over endringene i klasser og egenskaper, fra v.1.1 til denne versjonen av DCAT-AP-NO. Redaksjonelle justeringer av tekster (inkl. tekstlige beskrivelser, kommentarer og eksempler) er ikke tatt med i oversikten.
 
 [cols="15,15,35,35"]
@@ -28,7 +92,7 @@ Tabellen under gir en oversikt over endringene i klasser og egenskaper, fra v.1.
 |Datasett: tidsromsoppløsning |dcat:temporalResolution |Ny egenskap |Dette i henhold til BRegDCAT-AP
 |Datasett: utgivelsesdato |dct:issued |Range endret fra `rdfs:Literal typed as xsd:dateTime` til `rdfs:Literal typed as xsd:date or xsd:dateTime` |Dette i henhold til BRegDCAT-AP
 |Datatjeneste |dcat:DataService |Hele klassen er ny  |Dette i henhold til BRegDCAT-AP
-|Distribusjon: format|dct:format|Range endret fra `dct:MediaTypeOrExtent` til `dct:format`|Dette i henhold til BRegDCAT-AP
+|Distribusjon: format|dct:format|Range endret fra `dct:MediaTypeOrExtent` til `dct:MediaType`|
 |Distribusjon: geografisk oppløsning |dcat:spatialResolutionInMeters |Ny egenskap |Dette i henhold til BRegDCAT-AP
 |Distribusjon: i samsvar med |dct:conformsTo |Norsk navn endret fra `Distribusjon: samsvarer med` til `Distribusjon: i samsvar med` |
 |Distribusjon: komprimeringsformat |dcat:compressFormat |Ny egenskap |Dette i henhold til BRegDCAT-AP

--- a/docs/main.adoc
+++ b/docs/main.adoc
@@ -1,3 +1,4 @@
+include::locale/attributes.adoc[]
 = Standard for beskrivelse av datasett, datatjenester og datakataloger (DCAT-AP-NO)
 Høringsutkast til Versjon 2.0
 :doctype: book
@@ -14,18 +15,20 @@ Høringsutkast til Versjon 2.0
 image::images/digitaliseringsdirektoratet.png[width=50%, pdfwidth=30vw]
 
 
-Status: Høringsutkast +
-Publisert: 2020-06-02 +
-Lenke til gjeldende versjon: https://data.norge.no/specification/dcat-ap-no +
+*Status*: Høringsutkast +
+*Publisert*: 2020-06-02 +
+*Oppdatert*: 2020-07-03 +
+*Lenke til gjeldende versjon*: https://data.norge.no/specification/dcat-ap-no
+
+IMPORTANT: *Dette er en oppdatert versjon av høringsutkastet*: +
+Etter at høringsutkastet ble publisert 2. juni 2020, har det blitt  oppdateringer i EU sin BRegDCAT-AP som denne standarden er basert på. Den oppdaterte versjonen av BRegDCAT-AP dekker norske behov betydelig bedre, slik at de aller fleste norske utvidelsene ikke lenger trenger å være norske utvidelser. Høringsutkastet er derfor også blitt oppdatert. Se <<endringer-høringsutkastet, endringsloggen>> for oversikt over endringene.
 
 Dette er et høringsutkast til versjon 2.0 av “Standard for beskrivelse av datasett, datatjenester og datakataloger (DCAT-AP-NO)”. Standarden skal sikre at beskrivelser av offentlige data og datatjenester utføres på en felles, strukturert måte og i en maskinlesbar form. Standarden stiller krav til hva som _skal_, _bør_ og _kan_ være med i beskrivelsene, med spesifikasjon av dataformat.
 
 NOTE: *Innmelding av feil og mangler:* +
-Dersom du finner feil eller mangler i dokumentet, ber vi om at dette meldes inn på https://github.com/difi/dcat-ap-no/issues[Github Issues]. Dersom man ikke allerede har bruker på Github kan man opprette bruker gratis.
+Dersom du finner feil eller mangler i dokumentet, ber vi om at dette meldes inn på https://github.com/difi/dcat-ap-no/issues[Github Issues]. Dersom du ikke allerede har bruker på Github kan du opprette bruker gratis.
 
 include::shared/download.adoc[]
-
-include::locale/attributes.adoc[]
 
 include::01_Introduksjon.adoc[]
 


### PR DESCRIPTION
Etter at høringsutkastet ble publisert 2. juni 2020, har det blitt  oppdateringer i EU sin BRegDCAT-AP som denne standarden er basert på. Den oppdaterte versjonen av BRegDCAT-AP dekker norske behov betydelig bedre, slik at de aller fleste norske utvidelsene ikke lenger trenger å være norske utvidelser. 

Det er derfor behov for å oppdatering høringsutkastet. 

Tore oppdaterer UML-modellen som vil bli tatt med i senere PR. 

Lokalt generert html ser ok ut.