### PR TITLE
Retter skrivefeil ref. xl-ark rad 37.

### DIFF
--- a/docs/02_Avvik.adoc
+++ b/docs/02_Avvik.adoc
@@ -9,10 +9,10 @@ Denne versjonen av DCAT-AP-NO avviker BRegDCAT-AP på følgende måter:
 |*Klasse-/egenskapsnavn*|*URI for klassen/egenskapen*|*Avvik*|*Forklaring*
 |Datasett: begrep|dct:subject|Ikke eksplisitt tatt med i BRegDCAT-AP|Er i DCAT-AP-NO v.1.1
 |Datasett: følger|cpsv:follows|Endret fra valgfri til anbefalt|Denne erstatter egenskap Datasett: skjermingshjemmel som var anbefalt i DCAT-AP-NO v.1.1
-|Datasett: tema|dcat:theme|Endret fra anbefalt til obligatorisk, dermed også kardinalitet|Allerede i DCAT-AP-NO v.1.1
+|Datasett: tema|dcat:theme|Endret fra anbefalt til obligatorisk, dermed også multiplisitet|Allerede i DCAT-AP-NO v.1.1
 |Datasett: tilgangsnivå|dct:accessRights|Endret fra valgfri til anbefalt|Allerede i DCAT-AP-NO v.1.1
-|Datasett: utgiver|dct:publisher|Endret fra anbefalt til obligatorisk, dermed også kardinalitet|Allerede i DCAT-AP-NO v.1.1
-|Distribusjon: format|dct:format|Endret fra anbefalt til obligatorisk, dermed også kardinalitet|Allerede i DCAT-AP-NO v.1.1
+|Datasett: utgiver|dct:publisher|Endret fra anbefalt til obligatorisk, dermed også multiplisitet|Allerede i DCAT-AP-NO v.1.1
+|Distribusjon: format|dct:format|Endret fra anbefalt til obligatorisk, dermed også multiplisitet|Allerede i DCAT-AP-NO v.1.1
 |Distribusjon: format|dct:format|Range endret fra dct:MediaTypeOrExtent til dct:MediaType|
 |Tema|skos:Concept|Endret fra anbefalt til obligatorisk|Allerede i DCAT-AP-NO v.1.1
 |Tematisk skjema|skos:ConceptScheme|Endret fra anbefalt til obligatorisk|Allerede i DCAT-AP-NO v.1.1

--- a/docs/04b_Om_kravene.adoc
+++ b/docs/04b_Om_kravene.adoc
@@ -6,7 +6,7 @@ som er en utvidelse av DCAT-AP fra EU.
 
 Klasse::
 Obligatorisk (verb: skal, må)::: produsent/avsender av data skal oppgi informasjon om instanser av klassen; konsument/mottaker av data skal være i stand til å prosessere informasjon om instanser av klassen.
-Anbefalt (verb: bør)::: produsent/avsender av data bør oppgi informasjon om instanser av klassen; produsent/avsender av data skal oppgi informasjon om instanser av klassen hvis informasjonen er tilgjengelig; konsument/mottaker av data skal være i sand til å prosessere informasjon om instanser av klassen.
+Anbefalt (verb: bør)::: produsent/avsender av data bør oppgi informasjon om instanser av klassen; produsent/avsender av data skal oppgi informasjon om instanser av klassen hvis informasjonen er tilgjengelig; konsument/mottaker av data skal være i stand til å prosessere informasjon om instanser av klassen.
 Valgfri (verb: kan)::: produsent/avsender av data kan oppgi informasjon om instanser av klassen, men det er ikke påkrevd; konsument/mottaker av data skal være i stand til å prosessere informasjon om instanser av klassen.
 
 

--- a/docs/Klasse_Datatjeneste.adoc
+++ b/docs/Klasse_Datatjeneste.adoc
@@ -172,7 +172,7 @@ Klassen _Datatjeneste_ er valgfri.
 |URI| dct:conformsTo
 |Range| dct:Standard
 |Beskrivelse| Referanse til en spesifikasjon eller standard som datatjenesten implementerer.
-|Kardinalitet| 0..n
+|Multiplisitet| 0..n
 |Status| Valgfri
 |===
 
@@ -183,7 +183,7 @@ Klassen _Datatjeneste_ er valgfri.
 |URI| dcat:landingPage
 |Range| foaf:Document
 |Beskrivelse| Referanse til nettside som gir tilgang til datatjenesten, dens distribusjoner og/eller tilleggsinformasjon. Intensjonen er å peke til en landingsside hos den opprinnelige datautgiveren.
-|Kardinalitet| 0..1
+|Multiplisitet| 0..1
 |Status| Valgfri
 |===
 
@@ -194,7 +194,7 @@ Klassen _Datatjeneste_ er valgfri.
 |URI| dct:license
 |Range| dct:LicenseDocument
 |Beskrivelse| Inneholder lisensen som datatjenesten blir gjort tilgjengelig under.
-|Kardinalitet| 0..1
+|Multiplisitet| 0..1
 |Status| Valgfri
 |===
 

--- a/docs/Klasse_Offentlig_organisasjon.adoc
+++ b/docs/Klasse_Offentlig_organisasjon.adoc
@@ -50,7 +50,7 @@ Klassen _Offentlig organisasjon_ er anbefalt.
 |Beskrivelse|Brukes til å oppgi navnet til organisasjonen.
 |Multiplisitet|1..1
 |Status|Obligatorisk
-|Kommentar|Denne egenskapen er satt obligatorisk i BRegDCAT-AP for å være kompatiblel med CPSV-AP.
+|Kommentar|Denne egenskapen er satt obligatorisk i BRegDCAT-AP for å være kompatibel med CPSV-AP.
 |===
 
 == Anbefalte egenskaper for klassen _Offentlig organisasjon_

--- a/docs/XX_endringslogg.adoc
+++ b/docs/XX_endringslogg.adoc
@@ -85,7 +85,7 @@ Tabellen under gir en oversikt over endringene i klasser og egenskaper, fra v.1.
 |Datasett: produsent |dct:creator |Norsk navn endret fra `Datasett: skaper` til `Datasett: produsent` |Bedre dekkende navn
 |Datasett: produsent |dct:creator |Range er endret fra `rdfs:Resource` til `foaf:Agent` |Dette i henhold til BRegDCAT-AP
 |Datasett: proveniensbeskrivelse |dct:provenance |Norsk navn endret fra `Datasett: opphav` til `Datasett: proveniensbeskrivelse` |Bedre dekkende navn
-|Datasett: proveniensbeskrivelse |dct:provenance |Kardinalitet endret fra `0..1` til `0..n` |Dette i henhold til BRegDCAT-AP
+|Datasett: proveniensbeskrivelse |dct:provenance |Multiplisitet endret fra `0..1` til `0..n` |Dette i henhold til BRegDCAT-AP
 |Datasett: refererer til |dct:references |Range endret fra `dcat:Dataset` til `rdfs:Resource` |Dette i henhold til BRegDCAT-AP
 |[.line-through]#Datasett: skjermingshjemmel# |[.line-through]#dcatno:accessRightsComment# |Fjernet. Erstattes med `Datasett: følger (cpsv:follows)` |Unødvendig med dette norske avvik
 |Datasett: tema|dcat:theme|Range endret fra `dcat:theme, subproperty of dct:subject` til `dcat:them`|Dette i henhold til BRegDCAT-AP


### PR DESCRIPTION
'- "Kompatiblel"; 
- "sand" istedenfor "stand"
- Bytte ut 7 forekomster av «Kardinalitet» slik at de er samkjørt med «Multiplisitet» (167 forekomster) hvis en mener det samme.