### PR TITLE
Utkast dcat ap n ov2 shacl

### DIFF
--- a/examples/DCAT-AP-NO2.0-examples.ttl
+++ b/examples/DCAT-AP-NO2.0-examples.ttl
@@ -1,0 +1,409 @@
+@prefix : <https://examples.org/dcatno_Examples#> .
+@prefix oa: <https://www.w3.org/TR/annotation-vocab/#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dqv: <https://www.w3.org/TR/vocab-dqv/#dqv:> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dqvno: <https://data.norge.no/vocabulary/dqvno#> .
+@prefix brregOrg: <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/> .
+@prefix euDataTheme: <http://publications.europa.eu/resource/authority/data-theme/> .
+@prefix euDatasetType: <https://data.europa.eu/euodp/en/data/dataset/dataset-type/> .
+@base <https://examples.org/dcatno_Examples#> .
+
+<https://examples.org/dcatno_Examples#> rdf:type owl:Ontology ;
+                                         owl:versionIRI <urn:absolute:Example-v0.1> ;
+                                         rdfs:isDefinedBy "Digitaliseringsdirektoratet"@nb ,
+                                                          "Norwegian Digitalisation Agency"@en ;
+                                         rdfs:label "DCAT-AP-NO-eksempler"@nb ,
+                                                    "DCAT-AP-NO-examples"@en ;
+                                         owl:versionInfo """v0.1:
+- Based on DQV-AP-NO-example.
+- Added an exCatalog with mandatory property values."""@en ,
+                                                         """v0.1:
+- Basert på DQV-AP-NO-eksempel v.0.5.
+- Føyet til exCatalog med obligatoriske verdier."""@nb .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://purl.org/dc/terms/description
+dct:description rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/identifier
+dct:identifier rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/title
+dct:title rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#prefLabel
+skos:prefLabel rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Object Properties
+#################################################################
+
+###  http://purl.org/dc/terms/conformsTo
+dct:conformsTo rdf:type owl:ObjectProperty ;
+               rdfs:domain dcat:Dataset ;
+               rdfs:range dct:Standard .
+
+
+###  http://purl.org/dc/terms/publisher
+dct:publisher rdf:type owl:ObjectProperty ;
+              rdfs:domain dcat:Dataset ;
+              rdfs:range foaf:Agent .
+
+
+###  http://purl.org/dc/terms/type
+dct:type rdf:type owl:ObjectProperty ;
+         rdfs:domain dcat:Dataset ;
+         rdfs:range skos:Concept .
+
+
+###  http://www.w3.org/ns/dcat#dataset
+dcat:dataset rdf:type owl:ObjectProperty ;
+             rdfs:domain dcat:Catalog ;
+             rdfs:range dcat:Dataset .
+
+
+###  http://www.w3.org/ns/dcat#theme
+dcat:theme rdf:type owl:ObjectProperty ;
+           rdfs:domain dcat:Dataset ;
+           rdfs:range skos:Concept .
+
+
+###  https://www.w3.org/TR/annotation-vocab/#hasBody
+oa:hasBody rdf:type owl:ObjectProperty ;
+           rdfs:domain dqv:QualityAnnotation ;
+           rdfs:range oa:TextualBody .
+
+
+###  https://www.w3.org/TR/annotation-vocab/#hasTarget
+oa:hasTarget rdf:type owl:ObjectProperty ;
+             rdfs:domain oa:TextualBody ;
+             rdfs:range dcat:Dataset .
+
+
+###  https://www.w3.org/TR/annotation-vocab/#motivatedBy
+oa:motivatedBy rdf:type owl:ObjectProperty ;
+               rdfs:domain dqv:QualityAnnotation ;
+               rdfs:range oa:Motivation .
+
+
+###  https://www.w3.org/TR/vocab-dqv/#dqv:hasQualityAnnotation
+dqv:hasQualityAnnotation rdf:type owl:ObjectProperty ;
+                         rdfs:domain dcat:Dataset ;
+                         rdfs:range dqv:QualityAnnotation .
+
+
+###  https://www.w3.org/TR/vocab-dqv/#dqv:hasQualityMeasurement
+dqv:hasQualityMeasurement rdf:type owl:ObjectProperty ;
+                          rdfs:domain dcat:Dataset ;
+                          rdfs:range dqv:QualityMeasurement .
+
+
+###  https://www.w3.org/TR/vocab-dqv/#dqv:inDimension
+dqv:inDimension rdf:type owl:ObjectProperty ;
+                rdfs:domain dct:Standard ,
+                            dqv:QualityAnnotation ;
+                rdfs:range dqv:Dimension .
+
+
+###  https://www.w3.org/TR/vocab-dqv/#dqv:isMeasurementOf
+dqv:isMeasurementOf rdf:type owl:ObjectProperty ;
+                    rdfs:domain dqv:QualityMeasurement ;
+                    rdfs:range dqv:Metric .
+
+
+#################################################################
+#    Data properties
+#################################################################
+
+###  http://purl.org/dc/terms/format
+dct:format rdf:type owl:DatatypeProperty .
+
+
+###  http://purl.org/dc/terms/language
+dct:language rdf:type owl:DatatypeProperty .
+
+
+###  http://www.w3.org/2000/01/rdf-schema#value
+rdfs:value rdf:type owl:DatatypeProperty .
+
+
+###  https://www.w3.org/TR/vocab-dqv/#dqv:value
+dqv:value rdf:type owl:DatatypeProperty ;
+          rdfs:range xsd:boolean ,
+                     xsd:double ,
+                     xsd:nonNegativeInteger .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  http://purl.org/dc/terms/Standard
+dct:Standard rdf:type owl:Class .
+
+
+###  http://www.w3.org/2004/02/skos/core#Concept
+skos:Concept rdf:type owl:Class .
+
+
+###  http://www.w3.org/ns/dcat#Catalog
+dcat:Catalog rdf:type owl:Class .
+
+
+###  http://www.w3.org/ns/dcat#Dataset
+dcat:Dataset rdf:type owl:Class .
+
+
+###  http://xmlns.com/foaf/0.1/Agent
+foaf:Agent rdf:type owl:Class .
+
+
+###  https://www.w3.org/TR/annotation-vocab/#Motivation
+oa:Motivation rdf:type owl:Class .
+
+
+###  https://www.w3.org/TR/annotation-vocab/#TextualBody
+oa:TextualBody rdf:type owl:Class .
+
+
+###  https://www.w3.org/TR/vocab-dqv/#dqv:Dimension
+dqv:Dimension rdf:type owl:Class .
+
+
+###  https://www.w3.org/TR/vocab-dqv/#dqv:Metric
+dqv:Metric rdf:type owl:Class .
+
+
+###  https://www.w3.org/TR/vocab-dqv/#dqv:QualityAnnotation
+dqv:QualityAnnotation rdf:type owl:Class .
+
+
+###  https://www.w3.org/TR/vocab-dqv/#dqv:QualityCertificate
+dqv:QualityCertificate rdf:type owl:Class ;
+                       rdfs:subClassOf dqv:QualityAnnotation .
+
+
+###  https://www.w3.org/TR/vocab-dqv/#dqv:QualityMeasurement
+dqv:QualityMeasurement rdf:type owl:Class .
+
+
+###  https://www.w3.org/TR/vocab-dqv/#dqv:UserQualityFeedback
+dqv:UserQualityFeedback rdf:type owl:Class ;
+                        rdfs:subClassOf dqv:QualityAnnotation .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  http://publications.europa.eu/resource/authority/data-theme/GOVE
+euDataTheme:GOVE rdf:type owl:NamedIndividual ,
+                          skos:Concept .
+
+
+###  https://data.europa.eu/euodp/en/data/dataset/dataset-type/TEST_DATA
+euDatasetType:TEST_DATA rdf:type owl:NamedIndividual ,
+                                 skos:Concept .
+
+
+###  https://data.norge.no/vocabulary/dqvno#completeness
+dqvno:completeness rdf:type owl:NamedIndividual ,
+                            dqv:Dimension ;
+                   rdfs:comment "Dette er en predefinert kvalitetsdimensjon (dqv:Dimension)."@nb ,
+                                "This is a predefined quality dimension (dqv:Dimension)."@en ;
+                   skos:prefLabel "completeness"@en ,
+                                  "fullstendighet"@nb .
+
+
+###  https://data.norge.no/vocabulary/dqvno#isAuthoritative
+dqvno:isAuthoritative rdf:type owl:NamedIndividual ,
+                               dqv:QualityCertificate ;
+                      rdfs:comment "Dette er et predefinert kvalitetssertifikat (dqv:QualityCertificate) som sier at noe er autoritativt."@nb ,
+                                   "This is a predefined dqv:QualityCertificate stating that something is authoritative."@en ;
+                      rdfs:isDefinedBy dqvno:isAuthoritative ;
+                      skos:prefLabel "er autoritativ"@nb ,
+                                     "is authoritative"@en .
+
+
+###  https://data.norge.no/vocabulary/dqvno#missingObjects
+dqvno:missingObjects rdf:type owl:NamedIndividual ,
+                              dqv:Metric ;
+                     rdfs:comment "Dette er et predefinert kvalitetsmål (dqv:Metric) med boolsk verdi, som sier hvorvidt det mangler noen enheter i datasettet."@nb ,
+                                  "This is a predefined dqv:Metric in boolean, which states whether some objects are missing in the dataset."@en ;
+                     rdfs:isDefinedBy dqvno:missingObjects ;
+                     skos:prefLabel "manglende enheter"@nb ,
+                                    "missing objects"@en .
+
+
+###  https://data.norge.no/vocabulary/dqvno#numberOfMissingObjects
+dqvno:numberOfMissingObjects rdf:type owl:NamedIndividual ,
+                                      dqv:Metric ;
+                             rdfs:comment "Dette er et predefinert kvalitetsmål (dqv:Metric) med ikke-negativ-heltall, som sier antall enheter som mangler i datasettet."@nb ,
+                                          "This is a predefined metric (dqv:Metric) with nonNegativeInteger, which states the number of objects that are missing in the dataset."@en ;
+                             rdfs:isDefinedBy dqvno:numberOfMissingObjects ;
+                             skos:prefLabel "antall manglende enheter"@nb ,
+                                            "number of missing objects"@en .
+
+
+###  https://data.norge.no/vocabulary/dqvno#rateOfMissingObjects
+dqvno:rateOfMissingObjects rdf:type owl:NamedIndividual ,
+                                    dqv:Metric ;
+                           rdfs:comment "Dette er et predefinert kvalitetsmål (dqv:Metric) med double (uttrykt som prosent), som sier andel enheter som mangler i datasettet."@nb ,
+                                        "This is a predefined metric (dqv:Metric) with double (typed as percentage), which states the rate of missing objects in the dataset."@en ;
+                           rdfs:isDefinedBy dqvno:rateOfMissingObjects ;
+                           skos:prefLabel "andel manglende enheter"@nb ,
+                                          "rate of missing objects"@en .
+
+
+###  https://examples.org/dcatno_Examples#dsBuildings
+:dsBuildings rdf:type owl:NamedIndividual ,
+                      dcat:Dataset ;
+             dct:conformsTo :qsQualitySpecification ;
+             dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ;
+             dct:type euDatasetType:TEST_DATA ;
+             dcat:theme euDataTheme:GOVE ;
+             dqv:hasQualityAnnotation dqvno:isAuthoritative ,
+                                      :qaCompleteness ,
+                                      :qaUserFeedback ;
+             dqv:hasQualityMeasurement :qmMissingObjects ,
+                                       :qmNumberMissingObjects ,
+                                       :qmRateMissingObjects ;
+             dct:description "An example dataset."@en ,
+                             "Et eksempeldatasett."@nb ;
+             dct:identifier "https://exampledatasets.org/examples/dqvExamples#" ;
+             dct:title "Buildings - an example dataset"@en ,
+                       "Bygninger - et eksempeldatasett"@nb .
+
+
+###  https://examples.org/dcatno_Examples#exCatalog
+:exCatalog rdf:type owl:NamedIndividual ;
+           dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ;
+           dcat:dataset :dsBuildings ;
+           dct:description "An example catalog"@en ,
+                           "En eksempelkatalog"@nb ;
+           dct:identifier dcat:Catalog ;
+           dct:title "Eksempelkatalog"@nb ,
+                     "Example catalog"@en .
+
+
+###  https://examples.org/dcatno_Examples#qaCompleteness
+:qaCompleteness rdf:type owl:NamedIndividual ,
+                         dqv:QualityAnnotation ;
+                oa:hasBody :tekstFullstendighet ,
+                           :textCompleteness ;
+                oa:hasTarget :dsBuildings ;
+                oa:motivatedBy dqv:qualityAssessment ;
+                dqv:inDimension dqvno:completeness .
+
+
+###  https://examples.org/dcatno_Examples#qaUserFeedback
+:qaUserFeedback rdf:type owl:NamedIndividual ,
+                         dqv:UserQualityFeedback ;
+                oa:hasBody :tekstBrukertilbakemelding ,
+                           :textUserFeedback ;
+                oa:hasTarget :dsBuildings ;
+                oa:motivatedBy dqv:qualityAssessment ;
+                dqv:inDimension dqvno:completeness .
+
+
+###  https://examples.org/dcatno_Examples#qmMissingObjects
+:qmMissingObjects rdf:type owl:NamedIndividual ,
+                           dqv:QualityMeasurement ;
+                  dqv:isMeasurementOf dqvno:missingObjects ;
+                  dqv:value "true"^^xsd:boolean ;
+                  rdfs:comment "Ja, noen bygninger mangler i datasettet."@nb ,
+                               "Yes, some buildings are missing in the dataset."@en .
+
+
+###  https://examples.org/dcatno_Examples#qmNumberMissingObjects
+:qmNumberMissingObjects rdf:type owl:NamedIndividual ,
+                                 dqv:QualityMeasurement ;
+                        dqv:isMeasurementOf dqvno:numberOfMissingObjects ;
+                        dqv:value "2"^^xsd:nonNegativeInteger ;
+                        rdfs:comment "To bygninger mangler i datasettet."@nb ,
+                                     "Two buildings are missing in the dataset."@en .
+
+
+###  https://examples.org/dcatno_Examples#qmRateMissingObjects
+:qmRateMissingObjects rdf:type owl:NamedIndividual ,
+                               dqv:QualityMeasurement ;
+                      dqv:isMeasurementOf dqvno:rateOfMissingObjects ;
+                      dqv:value "0.02"^^xsd:double ;
+                      rdfs:comment "0.02% av bygninger mangler i datasettet."@nb ,
+                                   "0.02% of buildings are missing in the dataset."@en .
+
+
+###  https://examples.org/dcatno_Examples#qsQualitySpecification
+:qsQualitySpecification rdf:type owl:NamedIndividual ,
+                                 dct:Standard ;
+                        dct:title "Eksempel kvalitetsspesifikasjon"@nb ,
+                                  "Example quality specification"@en ;
+                        rdfs:comment "Denne spesifikasjonen dekker følgende kvalitetsdimensjoner: fullstendighet, nøyaktighet og konsistens."@nb ,
+                                     "The specification covers the following dimensions: completeness, accuracy and consistency."@en ;
+                        rdfs:seeAlso <https://exampledatasets.org/standards/quality-specification> ,
+                                     <https://exampledatasets.org/standards/kvalitetsspesifikasjon/> .
+
+
+###  https://examples.org/dcatno_Examples#tekstBrukertilbakemelding
+:tekstBrukertilbakemelding rdf:type owl:NamedIndividual ,
+                                    oa:TextualBody ;
+                           dct:format "text/plain" ;
+                           dct:language "nb" ;
+                           rdfs:value "Godt eksempeldatasett med god nok fullstendighet." .
+
+
+###  https://examples.org/dcatno_Examples#tekstFullstendighet
+:tekstFullstendighet rdf:type owl:NamedIndividual ,
+                              oa:TextualBody ;
+                     dct:format "text/plain" ;
+                     dct:language "nb" ;
+                     rdfs:value "Det tar i gjennomsnitt 24 dager fra en bygning står ferdig eller er revet til den er innlemmet i eller tatt ut fra datasettet." .
+
+
+###  https://examples.org/dcatno_Examples#textCompleteness
+:textCompleteness rdf:type owl:NamedIndividual ,
+                           oa:TextualBody ;
+                  dct:format "text/plain" ;
+                  dct:language "en" ;
+                  rdfs:value "On average there will be 24 days from a building is completed or demolished, to it is included in or excluded from the dataset." .
+
+
+###  https://examples.org/dcatno_Examples#textUserFeedback
+:textUserFeedback rdf:type owl:NamedIndividual ,
+                           oa:TextualBody ;
+                  dct:format "text/plain" ;
+                  dct:language "en" ;
+                  rdfs:value "Good example dataset with good enough completeness." .
+
+
+###  https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827
+<https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> rdf:type owl:NamedIndividual ,
+                                                                                              foaf:Agent .
+
+
+###  https://www.w3.org/TR/vocab-dqv/#dqv:qualityAssessment
+dqv:qualityAssessment rdf:type owl:NamedIndividual ,
+                               oa:Motivation ;
+                      rdfs:comment "Dette er en predefinert instans av oa:Motivation."@nb ,
+                                   "This is a predefined instance of oa:Motivation."@en ;
+                      rdfs:isDefinedBy dqv:qualityAssessment ;
+                      skos:prefLabel "kvalitetsvurdering"@nb ,
+                                     "quality assessment"@en .
+
+
+###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi

--- a/shacl/DCAT-AP-shacl_shapes_2.00.ttl
+++ b/shacl/DCAT-AP-shacl_shapes_2.00.ttl
@@ -1,0 +1,991 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix : <https://data.norge.no/specification/dcat-ap-no/#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix spdx: <http://spdx.org/rdf/terms#> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcatap: <http://data.europa.eu/r5r> .
+@prefix breg: <http://data.europa.eu/breg> .
+@prefix cpsv: <http://purl.org/vocab/cpsv#> .
+@prefix eli: <http://data.europa.eu/eli/ontology#> .
+@prefix cv: <http://data.europa.eu/m8g/> .
+@prefix dqv: <http://www.w3.org/ns/dqv#> .
+
+<https://data.norge.no/specification/dcat-ap-no/#shacl>
+    dcat:accessURL <https://github.com/Informasjonsforvaltning/dcat-ap-no/tree/develop/shacl>;
+    dcat:downloadURL <https://github.com/Informasjonsforvaltning/dcat-ap-no/tree/develop/shacl/DCAT-AP-NO-shacl_shapes_2.00.ttl> ;
+    dcatap:availability <http://data.europa.eu/r5r/draft> ;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE> ;
+    dct:conformsTo <https://www.w3.org/TR/shacl> ;
+    dct:creator [
+        foaf:homepage <https://www.digdir.no/> ;
+        foaf:name "Digitaliseringsdirektoratet"@nb ,
+           "Norwegian Digitalisation Agency"@en ;
+    ];
+    dct:license <https://creativecommons.org/licenses/by/4.0> ;
+    cc:attributionURL <http://ec.europa.eu/> ;
+    dct:modified "2020-11-20"^^xsd:date ;
+    dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ;
+    dct:relation <http://joinup.ec.europa.eu/collection/access-base-registries/solution/abr-specification-registry-registries/release/200> ;
+    dct:description "This document specifies the constraints on properties and classes expressed by DCAT-AP-NO in SHACL."@en ;
+    dct:title "The constraints of DCAT-AP-NO"@en ;
+    owl:versionInfo "0.1" ;
+    foaf:homepage <https://data.norge.no/specification/dcat-ap-no/> ;
+    foaf:maker [
+        foaf:mbox <mailto:informasjonsforvaltning@digdir.no> ;
+        foaf:name "Informasjonsforvaltning, Digitaliseringsdirektoratet" ;
+        foaf:page <https://www.digdir.no>
+    ] .
+
+
+
+#-------------------------------------------------------------------------
+# The shapes in this file cover all classes in DCAT-AP-NO 2.0.0.
+#
+#
+#-------------------------------------------------------------------------
+
+# Aktør (foaf:Agent), only added the Norwegian sh:name
+:Agent_Shape
+    a sh:NodeShape ;
+    sh:name "Agent"@en , "Aktør"@nb ;
+    sh:property [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path foaf:name ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:Concept ;
+        sh:maxCount 1 ;
+        sh:path dct:type ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:identifier ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass foaf:Agent .
+
+# Katalogpost (dcat:CatalogRecord), only added the Norwegian sh:name
+:CatalogRecord_Shape
+    a sh:NodeShape ;
+    sh:name "Catalogue Record"@en , "Katalogpost"@nb ;
+    sh:property [
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:node :DcatResource_Shape ;
+        sh:path foaf:primaryTopic ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:path dct:modified ;
+        sh:severity sh:Violation ;
+        sh:shape :DateOrDateTimeDataType_Shape
+    ], [
+        sh:class dct:Standard ;
+        sh:maxCount 1 ;
+        sh:path dct:conformsTo ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:node :DateOrDateTimeDataType_Shape ;
+        sh:path dct:issued ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:Concept ;
+        sh:maxCount 1 ;
+        sh:path adms:status ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:LinguisticSystem ;
+        sh:path dct:language ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:CatalogRecord ;
+        sh:maxCount 1 ;
+        sh:path dct:source ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dct:description ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dcat:CatalogRecord .
+
+# Sjekksum (spdx:Checksum), only added the Norwegian sh:name
+:Checksum_Shape
+    a sh:NodeShape ;
+    sh:name "Checksum"@en , "Sjekksum"@nb ;
+    sh:property [
+        sh:hasValue spdx:checksumAlgorithm_sha1 ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:path spdx:algorithm ;
+        sh:severity sh:Violation
+    ], [
+        sh:datatype xsd:hexBinary ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:path spdx:checksumValue ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass spdx:Checksum .
+
+# Datatjeneste (dcat:DataService), with Norwegian extensions
+:DataService_Shape
+    a sh:NodeShape ;
+    sh:name "Data Service"@en , "Datatjeneste"@nb ;
+    sh:property [
+        sh:maxCount 1 ; # Norwegian extension: added maxCount 1
+        sh:minCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dcat:endpointURL ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:identifier ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dcat:endpointDescription ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Dataset ;
+        sh:path dcat:servesDataset ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dct:description ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:RightsStatement ;
+        sh:maxCount 1 ;
+        sh:path dct:accessRights ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:Standard ;
+        sh:path dct:conformsTo ;
+        sh:severity sh:Violation
+    ], [
+        sh:class cpsv:Rule ;
+        sh:path cpsv:follows ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:LicenseDocument ;
+        sh:maxCount 1 ;
+        sh:path dct:licence ;
+        sh:severity sh:Violation
+    ], [ # Norwegian extension: Added dct:format
+        sh:class dct:MediaType ;
+        sh:path dct:format ;
+        sh:severity sh:Violation
+    ];
+    sh:targetClass dcat:DataService .
+
+# Datasett (dcat:Dataset), with Norwegian extensions
+:Dataset_Shape
+    a sh:NodeShape ;
+    sh:name "Dataset"@en , "Datasett"@nb ;
+    sh:property [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:description ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:identifier ;
+        sh:severity sh:Violation
+    ], [
+        sh:class vcard:Kind ;
+        sh:path dcat:contactPoint ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Distribution ;
+        sh:path dcat:distribution ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dcat:keyword ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Agent ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ; # Norwegian extension: Added minCount 1
+        sh:path dct:publisher ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:Location ;
+        sh:path dct:spatial ;
+        sh:severity sh:Violation
+    ], [
+	    sh:class dct:PeriodOfTime ;
+        sh:path dct:temporal ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:Concept ;
+        sh:minCount 1 ; # Norwegian extension: Added minCount 1
+        sh:path dcat:theme ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:RightsStatement ;
+        sh:maxCount 1 ;
+        sh:path dct:accessRights ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:Frequency ;
+        sh:maxCount 1 ;
+        sh:path dct:accrualPeriodicity ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:Standard ;
+        sh:path dct:conformsTo ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Agent ;
+        sh:maxCount 1 ;
+        sh:path dct:creator ;
+        sh:severity sh:Violation
+    ], [
+        sh:class cpsv:Rule ;
+        sh:path cpsv:follows ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Dataset ;
+        sh:path dct:hasPart ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dqv:QualityAnnotation ;
+        sh:path dqv:hasQualityAnnotation ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dqv:QualityMeasurement ;
+        sh:path dqv:hasQualityMeasurement ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Dataset ;
+        sh:path dct:hasVersion ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Dataset ;
+        sh:path dct:isPartOf ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dct:isReferencedBy ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Dataset ;
+        sh:path dct:isReplacedBy ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Dataset ;
+        sh:path dct:isVersionOf ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Document ;
+        sh:path dcat:landingPage ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:path dct:issued ;
+        sh:severity sh:Violation ;
+        sh:shape :DateOrDateTimeDataType_Shape
+    ], [
+        sh:class dct:LinguisticSystem ;
+        sh:path dct:language ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:path dct:modified ;
+        sh:severity sh:Violation ;
+        sh:shape :DateOrDateTimeDataType_Shape
+    ], [
+        sh:class adms:Identifier ;
+        sh:path adms:identifier ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Document ;
+        sh:path foaf:page ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:ProvenanceStatement ;
+        sh:path dct:provenance ;
+        sh:severity sh:Violation
+    ], [
+        sh:class prov:Attribution ;
+        sh:path prov:qualifiedAttribution ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Relationship ;
+        sh:path dcat:qualifiedRelation ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dct:references ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dct:relation ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Dataset ;
+        sh:path dct:replaces ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Dataset ;
+        sh:path dct:requires ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Distribution ;
+        sh:path adms:sample ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Dataset ;
+        sh:path dct:source ;
+        sh:severity sh:Violation
+    ], [
+        sh:datatype xsd:decimal ;
+        sh:path dcat:spatialResolutionInMeters ;
+        sh:severity sh:Violation
+    ], [
+        sh:datatype xsd:duration ;
+        sh:path dcat:temporalResolution ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:Concept ;
+        sh:maxCount 1 ; # Norwegian extension: Added maxCount 1 (error in BRegDCAT-AP-Shacl)
+        sh:path dct:type ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path owl:versionInfo ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path adms:versionNotes ;
+        sh:severity sh:Violation
+    ], [
+        sh:class prov:Activity ;
+        sh:path prov:wasGeneratedBy ;
+        sh:severity sh:Violation
+    ], [ # Norwegian extension: Added this property
+        sh:class skos:Concept ;
+        sh:path dct:subject ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dcat:Dataset .
+
+# Distribusjon (dcat:Distribution), with Norwegian extensions
+:Distribution_Shape
+    a sh:NodeShape ;
+    sh:name "Distribution"@en , "Distribusjon"@nb ;
+    sh:property [
+        sh:minCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI;
+        sh:path dcat:accessURL ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:Concept ;
+        sh:maxCount 1 ;
+        sh:path dcatap:availability ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dct:description ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:MediaType ; # Norwegian extension: Changed from dct:MediaTypeOrExtent
+        sh:maxCount 1 ;
+        sh:minCount 1 ; # Norwegian extension: Added minCount 1
+        sh:path dct:format ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:LicenseDocument ;
+        sh:maxCount 1 ;
+        sh:path dct:license ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:DataService ;
+        sh:path dcat:accessService ;
+        sh:severity sh:Violation
+    ], [
+        sh:datatype xsd:decimal ;
+        sh:maxCount 1 ;
+        sh:path dcat:byteSize ;
+        sh:severity sh:Violation
+    ], [
+        sh:class spdx:Checksum ;
+        sh:maxCount 1 ;
+        sh:path spdx:checksum ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:MediaType ;
+        sh:maxCount 1 ;
+        sh:path dcat:compressFormat ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:Standard ;
+        sh:path dct:conformsTo ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:BlankNodeOrIRI;
+        sh:path dcat:downloadURL ;
+        sh:severity sh:Violation
+    ], [
+        sh:class odrl:Policy ;
+        sh:maxCount 1 ;
+        sh:path odrl:hasPolicy ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:node :DateOrDateTimeDataType_Shape ;
+        sh:path dct:issued ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:LinguisticSystem ;
+        sh:path dct:language ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:MediaType ;
+        sh:maxCount 1 ;
+        sh:path dcat:mediaType ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:node :DateOrDateTimeDataType_Shape ;
+        sh:path dct:modified ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:MediaType ;
+        sh:maxCount 1 ;
+        sh:path dcat:packageFormat ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Document ;
+        sh:path foaf:page ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:RightsStatement ;
+        sh:maxCount 1 ;
+        sh:path dct:rights ;
+        sh:severity sh:Violation
+    ], [
+        sh:datatype xsd:decimal ;
+        sh:path dcat:spatialResolutionInMeters ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:Concept ;
+        sh:maxCount 1 ;
+        sh:path adms:status ;
+        sh:severity sh:Violation
+    ], [
+        sh:datatype xsd:duration ;
+        sh:path dcat:temporalResolution ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dcat:Distribution .
+
+# Dokument (foaf:Document), the whole class is a Norwegian extension
+:Document_Shape
+    a sh:NodeShape ;
+    sh:name "Document"@en , "Dokument"@nb ;
+    sh:property [
+        sh:datatype dct:LinguisticSystem ;
+        sh:maxCount 1 ;
+        sh:path dct:language ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass foaf:Document .
+
+# Identifikator (adms:Identifier), only added the Norwegian sh:name
+:Identifier_Shape
+    a sh:NodeShape ;
+    sh:name "Identifier"@en , "Identifikator"@nb ;
+    sh:property [
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:path skos:notation ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass adms:Identifier .
+
+# Regulativ ressurs (eli:LegalResource), only added the Norwegian sh:name
+:LegalResource_Shape
+    a sh:NodeShape ;
+    sh:name "Legal Resource"@en , "Regulativ ressurs"@nb ;
+    sh:property [
+        sh:minCount 1 ;
+        sh:class eli:ResourceType ;
+        sh:path dct:type ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dct:description ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dct:identifier ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:BlankNodeOrIRI;
+        sh:path rdfs:seeAlso ;
+        sh:severity sh:Violation
+    ], [
+        sh:class eli:LegalResource ;
+        sh:path dct:relation ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass eli:LegalResource .
+
+# Lisensdokument (dct:LicenseDocument), only added the Norwegian sh:name
+:LicenceDocument_Shape
+    a sh:NodeShape ;
+    sh:name "Licence Document"@en , "Lisensdokument"@nb ;
+    sh:property [
+        sh:class skos:Concept ;
+        sh:path dct:type ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dct:LicenseDocument .
+
+# Lokasjon (dct:Location), only added the Norwegian sh:name
+:Location_Shape
+    a sh:NodeShape ;
+    sh:name "Location"@en , "Lokasjon"@nb ;
+    sh:property [
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dcat:bbox ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dcat:centroid ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path locn:geometry ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dct:Location .
+
+# Tidsrom (dct:PeriodOfTime), only added the Norwegian sh:name
+:PeriodOfTime_Shape
+    a sh:NodeShape ;
+    sh:name "Period of Time"@en , "Tidsrom"@nb ;
+    sh:property [
+        sh:maxCount 1 ;
+        sh:path dcat:endDate ;
+        sh:severity sh:Violation ;
+        sh:shape :DateOrDateTimeDataType_Shape
+    ], [
+        sh:class time:Instant ;
+        sh:maxCount 1 ;
+        sh:path time:hasBeginning ;
+        sh:severity sh:Violation
+    ], [
+        sh:class time:Instant ;
+        sh:maxCount 1 ;
+        sh:path time:hasEnd ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:path dcat:startDate ;
+        sh:severity sh:Violation ;
+        sh:shape :DateOrDateTimeDataType_Shape
+    ] ;
+    sh:targetClass dct:PeriodOfTime .
+
+# Offentlig organisasjon (cv:PublicOrganisation), with Norwegian extensions
+:PublicOrganization_Shape
+    a sh:NodeShape ;
+    sh:name "Public Organisation"@en , "Offentlig organisasjon"@nb ;
+    sh:property [
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:identifier ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:minCount 1 ;
+        sh:path skos:prefLabel ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:Location ;
+        sh:minCount 1 ;
+        sh:path dct:spatial ;
+        sh:severity sh:Violation
+    ], [
+        sh:class locn:Address ;
+        sh:path locn:address ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:Concept ;
+        sh:path org:classification ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Document ;
+        # Norwegian extension: deleted maxCount 1
+        # sh:maxCount 1 ;
+        sh:path foaf:homepage ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass cv:PublicOrganisation .
+
+# Offentlig tjeneste (cpsv:PublicService), with Norwegian extensions
+:PublicRegistryService_Shape
+    a sh:NodeShape ;
+    sh:name "Public Registry Service"@en , "Offentlig tjeneste"@nb ;
+    sh:property [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:description ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:class cv:PublicOrganisation ;
+        sh:path cv:hasCompetentAuthority ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:identifier ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ], [
+        sh:class cpsv:PublicService ;
+        sh:path dct:hasPart ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Document ;
+        # Norwegian extension: deleted maxCount 1
+        # sh:maxCount 1 ;
+        sh:path foaf:homepage ;
+        sh:severity sh:Violation
+    ], [
+        sh:class cpsv:PublicService ;
+        sh:path dct:isPartOf ;
+        sh:severity sh:Violation
+    ], [
+        sh:node :DcatResource_Shape ;
+        sh:path cpsv:produces ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:Location ;
+        sh:path dct:spatial ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:Concept ;
+        sh:maxCount 1 ;
+        sh:path adms:status ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:Concept ;
+        sh:path cv:thematicArea ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:Concept ;
+        sh:path dct:type ;
+        sh:severity sh:Violation
+    ], [
+        sh:class cpsv:Rule ;
+        sh:path cpsv:follows ;
+        sh:severity sh:Violation
+    ], [
+        sh:class schema:ContactPoint ;
+        sh:path cv:hasContactPoint ;
+        sh:severity sh:Violation
+    ], [
+        sh:class eli:LegalResource ;
+        sh:path cv:hasLegalResouce ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass cpsv:PublicService .
+
+# Katalog (dcat:Catalog), only with the Norwegian sh:name
+:Catalog_Shape
+    a sh:NodeShape ;
+    sh:name "Registry Catalogue"@en , "Katalog"@nb ;
+    sh:property [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:description ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:path dct:identifier ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Agent ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:path dct:publisher ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:Frequency ;
+        sh:maxCount 1 ;
+        sh:path dct:accrualPeriodicity ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Dataset ;
+        sh:path dcat:dataset ;
+        sh:severity sh:Violation
+    ],  [
+        sh:class foaf:Document ;
+        sh:maxCount 1 ;
+        sh:path foaf:homepage ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:node :DateOrDateTimeDataType_Shape ;
+        sh:path dct:issued ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:LinguisticSystem ;
+        sh:path dct:language ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:LicenseDocument ;
+        sh:maxCount 1 ;
+        sh:path dct:license ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:node :DateOrDateTimeDataType_Shape ;
+        sh:path dct:modified ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:ProvenanceStatement ;
+        sh:path dct:provenance ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:Location ;
+        sh:path dct:spatial ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:ConceptScheme ;
+        sh:path dcat:themeTaxonomy ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Catalog ;
+        sh:path dcat:catalog ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Agent ;
+        sh:maxCount 1 ;
+        sh:path dct:creator ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Catalog ;
+        sh:path dct:hasPart ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Catalog ;
+        sh:maxCount 1 ;
+        sh:path dct:isPartOf ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:CatalogRecord ;
+        sh:path dcat:record ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:RightsStatement ;
+        sh:maxCount 1 ;
+        sh:path dct:rights ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:DataService ;
+        sh:path dcat:service ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dcat:Catalog .
+
+# Relasjon (dcat:Relationship), only with the Norwegian sh:name
+:Relationship_Shape
+    a sh:NodeShape ;
+    sh:name "Relationship"@en , "Relasjon"@nb ;
+    sh:property [
+        sh:node :DcatResource_Shape ;
+        sh:minCount 1 ;
+        sh:path dct:relation ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:class dcat:Role ;
+        sh:path dcat:hadRole ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dcat:Relationship .
+
+# Regel (cpsv:Rule), only with the Norwegian sh:name
+:Rule_Shape
+    a sh:NodeShape ;
+    sh:name "Rule"@en , "Regel"@nb ;
+    sh:property [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:description ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:path dct:identifier ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ], [
+        sh:class eli:LegalResource ;
+        sh:path cpsv:implements ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:LinguisticSystem ;
+        sh:path dct:language ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:class skos:Concept ;
+        sh:path dct:type ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass cpsv:Rule .
+
+# Standard (dct:Standard), the whole class is an Norwegian extensions
+:Standard_Shape
+    a sh:NodeShape ;
+    sh:name "Standard"@en , "Standard"@nb ;
+    sh:property [
+        sh:minCount 1;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path owl:versionInfo ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:BlankNodeOrIRI;
+        sh:path rdfs:seeAlso ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dct:Standard .
+
+# Tematisk skjema (skos:ConceptScheme), only sh:names
+:CategoryScheme_Shape
+    a sh:NodeShape ;
+    # Changed the English sh:name - typo of BRegDCAT-AP-SHACL
+    sh:name "Thematic Scheme"@en , "Tematisk skjema"@nb ;
+    sh:property [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass skos:ConceptScheme .
+
+# Tema (skos:Concept), only the sh:names
+:Category_Shape
+    a sh:NodeShape ;
+    sh:name "Theme"@en , "Tema"@nb ;
+    sh:property [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path skos:prefLabel ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass skos:Concept .
+
+:DateOrDateTimeDataType_Shape
+    a sh:NodeShape ;
+    rdfs:comment "Date time date disjunction shape checks that a datatype property receives a date or a dateTime literal" ;
+    rdfs:label "Date time date disjunction" ;
+    sh:message "The values must be data typed as either xsd:date or xsd:dateTime" ;
+    sh:or ([
+            sh:datatype xsd:date
+        ]
+        [
+            sh:datatype xsd:dateTime
+        ]
+    ) .
+
+:DcatResource_Shape
+    a sh:NodeShape ;
+    rdfs:comment "the union of Catalog, Dataset and DataService" ;
+    rdfs:label "dcat:Resource" ;
+    sh:message "The node is either a Catalog, Dataset or a DataService" ;
+    sh:or ([
+            sh:class dcat:Catalog
+        ]
+        [
+            sh:class dcat:Dataset
+        ]
+        [
+            sh:class dcat:DataService
+        ]
+    ) .


### PR DESCRIPTION
Første utkast til DCAT-AP-NO-SHACL, basert på BRegDCAT-AP-SHACL. Komplett men med forbehold om feil og mangler (som også kan finnes i BRegDCAT-AP-SHACL, virker det som).