### PR TITLE
Issue #361 revisited (multiplisitet 0..n).

### DIFF
--- a/docs/02_Avvik.adoc
+++ b/docs/02_Avvik.adoc
@@ -15,6 +15,7 @@ Denne versjonen av DCAT-AP-NO avviker BRegDCAT-AP (v.2.00) på følgende måter:
 |Datasett: utgiver|dct:publisher|Endret fra anbefalt til obligatorisk, dermed også multiplisitet|Allerede i DCAT-AP-NO v.1.1
 |Datatjeneste: endepunktsURL | dcat:endpointURL | Multiplisitet endret fra 1..n til 1..1 | Datatjeneste med flere ulike endepunktsURLer bør betraktes som flere ulike datatjenester
 |Datatjeneste: format |dct:format |Ikke eksplisitt tatt med i BRegDCAT-AP | Føyet til for å ha konsistens mellom distribusjon og datatjeneste.
+|Distribusjon: format | dct:format | Multiplisitet endret fra 0..1 til 0..n | For å kunne ta høyde for at en distribusjon kan ha flere formater.
 |Distribusjon: medietype |dcat:mediaType |Multiplisitet endret fra 0..1 til 0..n | For å kunne ta høyde for at en distribusjon kan være i flere ulike medietyper.
 |Distribusjon: status |adms:status |Endret fra valgfri til anbefalt | Status på en distribusjon er viktig å vite når man skal vurdere om distribusjonen skal/kan brukes.
 |Dokument: språk | dct:language | Ikke eksplisitt tatt med i BRegDCAT-AP | For å kunne referere til språk foaf:Document er i

--- a/docs/main.adoc
+++ b/docs/main.adoc
@@ -22,7 +22,7 @@ Dersom du finner feil eller mangler i dokumentet, ber vi om at dette meldes inn 
 *Status*: Gjeldende +
 *Versjon*: 2.0.1 (se <<Endringslogg, endringsloggen>>) +
 *Publisert*: 2020-10-29 +
-*Oppdatert*: 2021-01-06 +
+*Oppdatert*: 2021-01-14 +
 *Gjeldende versjon*: https://data.norge.no/specification/dcat-ap-no +
 *Forrige versjon*: https://data.norge.no/specification/dcat-ap-no/v1.1/ +
 *Redaktørens utkast*: https://informasjonsforvaltning.github.io/dcat-ap-no/

--- a/shacl/DCAT-AP-NO-shacl_shapes_2.00.ttl
+++ b/shacl/DCAT-AP-NO-shacl_shapes_2.00.ttl
@@ -429,7 +429,7 @@
         sh:severity sh:Violation
     ], [
         sh:class dct:MediaTypeOrExtent ;
-        sh:maxCount 1 ;
+        # sh:maxCount 1 ; # Norwegian extension 0..n
         sh:path dct:format ;
         sh:severity sh:Violation
     ], [


### PR DESCRIPTION
Multiplisitet for dct:format i dcat:Distribution skal være 0..n for å kunne ha flere formater (dermed et avvik fra BRegDCAT-AP).