### PR TITLE
Lage en ad-hoc workflow for ontologi-filer

### DIFF
--- a/.github/workflows/publish-ontology-from-develop-to-production.yml
+++ b/.github/workflows/publish-ontology-from-develop-to-production.yml
@@ -1,4 +1,4 @@
-name: Publish ontology to staging.fellesdatakatalog.digdir.no/vocabulary
+name: (ad hoc) Publish ontology from develop to data.norge.no/vocabulary
 
 on:
   push:
@@ -16,15 +16,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Upload rdf to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@v3.0.0
-        id: upload-rdf
+      - name: Upload files to static-rdf-server
+        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@v3.2.0
+        id: upload-files
         with:
           ontology-type: "vocabulary"
           ontology: "dcatno"
-          host: "https://staging.fellesdatakatalog.digdir.no"
+          host: "https://data.norge.no"
           api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY_STAGING }}
           files: |
             ontology/dcatno.ttl text/turtle en


### PR DESCRIPTION
Må først lage en ad-hoc workflow som publiserer ontologi-filer fra develop-branchen til data.norge.no/vocabulary. 

Forklaring hvorfor en slik ad-hoc workflow: Den normale workflow er å merge ontologifilene til først develop-branchen og deretter til v2-branchen som så vil komme ut på data.norge.no/vocabulary. Men, det er en stor diff mellom develop og v2 for spesifikasjonen, og alle disse endringene ville også blitt tatt med til data.norge.no hvis vi bruker/følger den normale workflow. Det er Øystein som holder på å oppdatere spesifikasjonen, og han har ennå ikke valgt å få disse endringene ut til data.norge.no.  