### PR TITLE
Update DCAT-AP-NO-shacl_shapes_2.00.ttl

### DIFF
--- a/shacl/DCAT-AP-NO-shacl_shapes_2.00.ttl
+++ b/shacl/DCAT-AP-NO-shacl_shapes_2.00.ttl
@@ -1,5 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix : <https://data.norge.no/specification/dcat-ap-no/#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix cc: <http://creativecommons.org/ns#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
@@ -26,10 +25,13 @@
 @prefix cv: <http://data.europa.eu/m8g/> .
 @prefix dqv: <http://www.w3.org/ns/dqv#> .
 
+@prefix : <https://data.norge.no/vocabulary/dcatno-shacl#> .
+
+# About this SHACL:
 <https://data.norge.no/specification/dcat-ap-no/#shacl>
     dcat:accessURL <https://github.com/Informasjonsforvaltning/dcat-ap-no/tree/develop/shacl>;
     dcat:downloadURL <https://github.com/Informasjonsforvaltning/dcat-ap-no/tree/develop/shacl/DCAT-AP-NO-shacl_shapes_2.00.ttl> ;
-    dcatap:availability <http://data.europa.eu/r5r/draft> ;
+    dcatap:availability <http://publications.europa.eu/resource/authority/planned-availability/STABLE> ;
     dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE> ;
     dct:conformsTo <https://www.w3.org/TR/shacl> ;
     dct:creator [
@@ -37,47 +39,52 @@
         foaf:name "Digitaliseringsdirektoratet"@nb ,
            "Norwegian Digitalisation Agency"@en ;
     ];
-    dct:license <https://creativecommons.org/licenses/by/4.0> ;
-    cc:attributionURL <http://ec.europa.eu/> ;
-    dct:modified "2021-11-22"^^xsd:date ;
-    dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ;
-    dct:relation <http://joinup.ec.europa.eu/collection/access-base-registries/solution/abr-specification-registry-registries/release/200> ;
-    dct:description "This document specifies the constraints on properties and classes expressed by DCAT-AP-NO in SHACL."@en ;
-    dct:title "The constraints of DCAT-AP-NO"@en ;
-    owl:versionInfo "0.8" ;
-    foaf:homepage <https://data.norge.no/specification/dcat-ap-no/> ;
+    foaf:homepage <https://github.com/Informasjonsforvaltning/dcat-ap-no/tree/develop/shacl> ;
     foaf:maker [
         foaf:mbox <mailto:informasjonsforvaltning@digdir.no> ;
-        foaf:name "Informasjonsforvaltning, Digitaliseringsdirektoratet" ;
-        foaf:page <https://www.digdir.no>
-    ] .
-
-
+        foaf:name "Informasjonsforvaltning, Digitaliseringsdirektoratet"@nb ;
+        foaf:page <https://www.digdir.no> ;
+    ] ;
+    dct:license <http://publications.europa.eu/resource/authority/licence/CC_BY_4_0> ;
+    cc:attributionURL <http://ec.europa.eu/> ;
+    dct:publisher <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/991825827> ;
+    dct:relation <http://joinup.ec.europa.eu/collection/access-base-registries/solution/abr-specification-registry-registries/release/200> ;
+    dct:description "This document specifies the constraints on properties and classes of DCAT-AP-NO, expressed by in SHACL."@en ;
+    dct:title "SHACL-shapes for DCAT-AP-NO"@en ;
+    dct:modified "2024-04-25"^^xsd:date ;
+    dcat:version "2.2.011" ;
+    adms:versionNotes "This version doesn't check the class, but only if the value is an IRI, when the value should be from a Controlled Vocabulary (since not all Controlled Vocabularies are typed as DCAT requires)"@en ,
+        "This incl. also ref. to external resources, e.g. foaf:Document, skos:Concept etc."@en, 
+        "Added also user-friendly sh:message"@en ;
+    rdfs:commet "Validated SUCCESS at https://www.itb.ec.europa.eu/shacl/shacl/upload"@en ;
+    .
 
 #-------------------------------------------------------------------------
-# The shapes in this file cover all classes in DCAT-AP-NO 2.x.y.
-#
-#
+# The shapes in this file cover all classes in DCAT-AP-NO 2.2.x.
 #-------------------------------------------------------------------------
 
-# Aktør (foaf:Agent), only added the Norwegian sh:name
+# Aktør (foaf:Agent)
 :Agent_Shape
     a sh:NodeShape ;
-    sh:name "Agent"@en , "Aktør"@nb ;
-    sh:property [
+    rdfs:label "Agent"@en , "Aktør"@nb ;
+    sh:property [ # navn
         sh:minCount 1 ;
         sh:nodeKind sh:Literal ;
         sh:path foaf:name ;
+        sh:message "foaf:name skal ha minst én verdi som skal være Literal"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class skos:Concept ;
-        sh:maxCount 1 ;
-        sh:path dct:type ;
-        sh:severity sh:Violation
-    ], [
+    ], [ # organisasjonsidentifikator
         sh:maxCount 1 ;
         sh:nodeKind sh:Literal ;
         sh:path dct:identifier ;
+        sh:message "dct:identifier kan ha maks. én verdi som skal være Literal"@nb ;
+        sh:severity sh:Violation
+    ], [ # utgivertype
+#        sh:class skos:Concept ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+        sh:path dct:type ;
+        sh:message "dct:type kan ha maks. én verdi som skal være IRI"@nb ;
         sh:severity sh:Violation
     ] ;
     sh:and (
@@ -92,935 +99,1231 @@
     # sh:targetClass foaf:Agent ;
    .
 
-# Katalogpost (dcat:CatalogRecord), only added the Norwegian sh:name
-:CatalogRecord_Shape
-    a sh:NodeShape ;
-    sh:name "Catalogue Record"@en , "Katalogpost"@nb ;
-    sh:property [
-        sh:maxCount 1 ;
-        sh:minCount 1 ;
-        sh:node :DcatResource_Shape ;
-        sh:path foaf:primaryTopic ;
-        sh:severity sh:Violation
-    ], [
-        sh:maxCount 1 ;
-        sh:minCount 1 ;
-        sh:path dct:modified ;
-        sh:severity sh:Violation ;
-        sh:node :DateOrDateTimeDataType_Shape
-    ], [
-        sh:class dct:Standard ;
-        sh:maxCount 1 ;
-        sh:path dct:conformsTo ;
-        sh:severity sh:Violation
-    ], [
-        sh:maxCount 1 ;
-        sh:node :DateOrDateTimeDataType_Shape ;
-        sh:path dct:issued ;
-        sh:severity sh:Violation
-    ], [
-        sh:class skos:Concept ;
-        sh:maxCount 1 ;
-        sh:path adms:status ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dct:LinguisticSystem ;
-        sh:path dct:language ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dcat:CatalogRecord ;
-        sh:maxCount 1 ;
-        sh:path dct:source ;
-        sh:severity sh:Violation
-    ], [
-        sh:nodeKind sh:Literal ;
-        sh:path dct:title ;
-        sh:severity sh:Violation
-    ], [
-        sh:nodeKind sh:Literal ;
-        sh:path dct:description ;
-        sh:severity sh:Violation
-    ], [ ## Norwegian extension
-        sh:node :LicenseTypeRestriction ;
-        sh:nodeKind sh:IRI ;
-        sh:path dct:license ;
-        sh:severity sh:Violation ;
-        sh:message "Bruk av Kontrollert Vokabular: Det som dct:license peker på finnes ikke i EU sin liste over predefinerte lisenser (http(s)://publications.europa.eu/resource/authority/licence)."@nb ;
-    ] ;
-    sh:targetClass dcat:CatalogRecord .
-
-# Sjekksum (spdx:Checksum), only added the Norwegian sh:name
-:Checksum_Shape
-    a sh:NodeShape ;
-    sh:name "Checksum"@en , "Sjekksum"@nb ;
-    sh:property [
-        sh:hasValue spdx:checksumAlgorithm_sha1 ;
-        sh:maxCount 1 ;
-        sh:minCount 1 ;
-        sh:path spdx:algorithm ;
-        sh:severity sh:Violation
-    ], [
-        sh:datatype xsd:hexBinary ;
-        sh:maxCount 1 ;
-        sh:minCount 1 ;
-        sh:path spdx:checksumValue ;
-        sh:severity sh:Violation
-    ] ;
-    sh:targetClass spdx:Checksum .
-
-# Datatjeneste (dcat:DataService), with Norwegian extensions
-:DataService_Shape
-    a sh:NodeShape ;
-    sh:name "Data Service"@en , "Datatjeneste"@nb ;
-    sh:property [
-        sh:maxCount 1 ; # Norwegian extension: added maxCount 1
-        sh:minCount 1 ;
-        sh:nodeKind sh:BlankNodeOrIRI ;
-        sh:path dcat:endpointURL ;
-        sh:severity sh:Violation
-    ], [
-        sh:minCount 1 ;
-        sh:nodeKind sh:Literal ;
-        sh:path dct:identifier ;
-        sh:severity sh:Violation
-    ], [
-        sh:minCount 1 ;
-        sh:nodeKind sh:Literal ;
-        sh:path dct:title ;
-        sh:severity sh:Violation
-    ], [
-        sh:nodeKind sh:BlankNodeOrIRI ;
-        sh:path dcat:endpointDescription ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dcat:Dataset ;
-        sh:path dcat:servesDataset ;
-        sh:severity sh:Violation
-    ], [
-        sh:nodeKind sh:Literal ;
-        sh:path dct:description ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dct:RightsStatement ;
-        sh:maxCount 1 ;
-        sh:path dct:accessRights ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dct:Standard ;
-        sh:path dct:conformsTo ;
-        sh:severity sh:Violation
-    ], [
-        sh:class cpsv:Rule ;
-        sh:path cpsv:follows ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dct:LicenseDocument ;
-        sh:maxCount 1 ;
-        sh:path dct:license ;
-        sh:severity sh:Violation
-    ], [ # Norwegian extension: Added dct:format
-        sh:class dct:MediaTypeOrExtent ;
-        sh:path dct:format ;
-        sh:severity sh:Violation
-    ], [ ## Norwegian extension, check Controlled Vocab for dct:format
-        sh:node :FileTypeRestriction ;
-        sh:nodeKind sh:IRI ;
-        sh:path dct:format ;
-        sh:severity sh:Violation
-    ], [ # Norwegian extension: Added dcat:mediaType
-        sh:class dct:MediaType ;
-        sh:path dcat:mediaType ;
-        sh:severity sh:Violation
-    ];
-    sh:targetClass dcat:DataService .
-
-# Datasett (dcat:Dataset), with Norwegian extensions
+# Datasett (dcat:Dataset)
 :Dataset_Shape
     a sh:NodeShape ;
-    sh:name "Dataset"@en , "Datasett"@nb ;
-    sh:property [
+    rdfs:label "Dataset"@en , "Datasett"@nb ;
+    sh:property [ # beskrivelse
         sh:minCount 1 ;
         sh:nodeKind sh:Literal ;
         sh:path dct:description ;
+        sh:message "dct:description skal ha minst én verdi som skal være Literal"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:minCount 1 ;
-        sh:nodeKind sh:Literal ;
-        sh:path dct:title ;
-        sh:severity sh:Violation
-    ], [
+    ], [ # identifikator
         sh:minCount 1 ;
         sh:nodeKind sh:Literal ;
         sh:path dct:identifier ;
+        sh:message "dct:identifier skal ha minst én verdi som skal være Literal"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class vcard:Kind ;
-        sh:path dcat:contactPoint ;
+    ], [ # tema
+#        sh:class skos:Concept ;
+        sh:nodeKind sh:IRI ;
+        sh:minCount 1 ; # Norwegian extension: Added minCount 1
+        sh:path dcat:theme ;
+        sh:message "dcat:theme skal ha minst én verdi som skal være IRI"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class dcat:Distribution ;
-        sh:path dcat:distribution ;
-        sh:severity sh:Violation
-    ], [
+    ], [ # tittel
+        sh:minCount 1 ;
         sh:nodeKind sh:Literal ;
-        sh:path dcat:keyword ;
-        sh:severity sh:Violation
-    ], [
-        sh:class foaf:Agent ;
+        sh:path dct:title ;
+        sh:message "dct:title skal ha minst én verdi som skal være Literal"@nb ;
+        sh:severity sh:Violation 
+    ], [ # utgiver
+#        sh:class foaf:Agent ;
+        sh:nodeKind sh:IRI ;
         sh:maxCount 1 ;
         sh:minCount 1 ; # Norwegian extension: Added minCount 1
         sh:path dct:publisher ;
+        sh:message "dct:publisher skal ha én og bare én verdi som skal være IRI"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class dct:Location ;
+    ], [ # begrep, Norwegian extension: Added this property
+#        sh:class skos:Concept ;
+        sh:nodeKind sh:IRI ;
+        sh:path dct:subject ;
+        sh:message "dct:subject skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # ble generert ved 
+#        sh:class prov:Activity ;
+        sh:nodeKind sh:IRI ;
+        sh:path prov:wasGeneratedBy ;
+        sh:message "prov:wasGeneratedBy skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # datasettdistribusjon
+        sh:class dcat:Distribution ;
+        sh:path dcat:distribution ;
+        sh:message "dcat:distribution skal referere til en instans av dcat:Distribution"@nb ;
+        sh:severity sh:Violation
+    ], [ # dekningsområde
+#        sh:class dct:Location ;
+        sh:nodeKind sh:IRI ;
         sh:path dct:spatial ;
+        sh:message "dct:spatial skal være IRI"@nb ;
         sh:severity sh:Violation
-    ], [
-	    sh:class dct:PeriodOfTime ;
-        sh:path dct:temporal ;
+    ], [ # emneord
+        sh:nodeKind sh:Literal ;
+        sh:path dcat:keyword ;
+        sh:message "dcat:keywork skal være Literal"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class skos:Concept ;
-        sh:minCount 1 ; # Norwegian extension: Added minCount 1
-        sh:path dcat:theme ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dct:RightsStatement ;
-        sh:maxCount 1 ;
-        sh:path dct:accessRights ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dct:Frequency ;
-        sh:maxCount 1 ;
-        sh:path dct:accrualPeriodicity ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dct:Standard ;
-        sh:path dct:conformsTo ;
-        sh:severity sh:Violation
-    ], [
-        sh:class foaf:Agent ;
-        sh:maxCount 1 ;
-        sh:path dct:creator ;
-        sh:severity sh:Violation
-    ], [
+    ], [ # følger
         sh:class cpsv:Rule ;
         sh:path cpsv:follows ;
+        sh:message "cpsv:follows skal referere til en instans av cpsv:Rule"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class dcat:Dataset ;
-        sh:path dct:hasPart ;
+    ], [ # kontaktpunkt
+        sh:or (
+            [ sh:class vcard:Kind ]
+            [ sh:class vcard:Organization ] ) ;
+        sh:path dcat:contactPoint ;
+        sh:message "dcat:contactPoint skal referere til en instans av vcard:Kind eller vcard:Organization"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class dqv:QualityAnnotation ;
-        sh:path dqv:hasQualityAnnotation ;
+    ], [ # tidsrom
+	    sh:class dct:PeriodOfTime ;
+        sh:path dct:temporal ;
+        sh:message "dct:temporal skal referere til en instans av dct:PeriodOfTime"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class dqv:QualityMeasurement ;
-        sh:path dqv:hasQualityMeasurement ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dcat:Dataset ;
-        sh:path dct:hasVersion ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dcat:Dataset ;
-        sh:path dct:isPartOf ;
-        sh:severity sh:Violation
-    ], [
-        sh:nodeKind sh:BlankNodeOrIRI ;
-        sh:path dct:isReferencedBy ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dcat:Dataset ;
-        sh:path dct:isReplacedBy ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dcat:Dataset ;
-        sh:path dct:isVersionOf ;
-        sh:severity sh:Violation
-    ], [
-        sh:class foaf:Document ;
-        sh:path dcat:landingPage ;
-        sh:severity sh:Violation
-    ], [
+    ], [ # tilgangsnivå
+#        sh:class dct:RightsStatement ;
+        sh:nodeKind sh:IRI ;
         sh:maxCount 1 ;
-        sh:path dct:issued ;
-        sh:severity sh:Violation ;
-        sh:node :DateOrDateTimeDataType_Shape
-    ], [
-        sh:class dct:LinguisticSystem ;
-        sh:path dct:language ;
+        sh:path dct:accessRights ;
+        sh:message "dct:accessRights kan ha maks. én verdi som skal være IRI"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:maxCount 1 ;
-        sh:path dct:modified ;
-        sh:severity sh:Violation ;
-        sh:node :DateOrDateTimeDataType_Shape
-    ], [
+    ], [ # annen identifikator
         sh:class adms:Identifier ;
         sh:path adms:identifier ;
+        sh:message "adms:identifier skal referere til en instans av adms:Identifier"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class foaf:Document ;
+    ], [ # dokumentasjon
+#        sh:class foaf:Document ;
+        sh:nodeKind sh:IRI ;
         sh:path foaf:page ;
+        sh:message "foaf:page skal være en IRI"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class dct:ProvenanceStatement ;
-        sh:path dct:provenance ;
-        sh:severity sh:Violation
-    ], [
-        sh:class prov:Attribution ;
-        sh:path prov:qualifiedAttribution ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dcat:Relationship ;
-        sh:path dcat:qualifiedRelation ;
-        sh:severity sh:Violation
-    ], [
-        sh:nodeKind sh:BlankNodeOrIRI ;
-        sh:path dct:references ;
-        sh:severity sh:Violation
-    ], [
-        sh:nodeKind sh:BlankNodeOrIRI ;
-        sh:path dct:relation ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dcat:Dataset ;
-        sh:path dct:replaces ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dcat:Dataset ;
-        sh:path dct:requires ;
-        sh:severity sh:Violation
-    ], [
+    ], [ # eksempeldata 
         sh:class dcat:Distribution ;
         sh:path adms:sample ;
+        sh:message "adms:sample skal referere til en instans av dcat:Distribution"@nb ;
         sh:severity sh:Violation
-    ], [
+    ], [ # endringsdato
+        sh:maxCount 1 ;
+        sh:path dct:modified ;
+        sh:message "dct:modified kan ha maks. én verdi"@nb ;
+        sh:severity sh:Violation ;
+    ], [ # er del av
+        sh:class dcat:Dataset ;
+        sh:path dct:isPartOf ;
+        sh:message "dct:isPartOf skal referere til en instans av dcat:Dataset"@nb ;
+        sh:severity sh:Violation
+    ], [ # er påkrevd av 
+        sh:class dcat:Dataset ;
+        sh:path dct:isRequiredBy ;
+        sh:message "dct:isRequiredBy skal referere til en instans av dcat:Dataset"@nb ;
+        sh:severity sh:Violation
+    ], [ # er referert av
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dct:isReferencedBy ;
+        sh:message "dct:isReferencedBy skal være blank node eller IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # er versjon av
+        sh:class dcat:Dataset ;
+        sh:path dct:isVersionOf ;
+        sh:message "dct:isVersionOf skal referere til en instans av dcat:Dataset"@nb ;
+        sh:severity sh:Violation
+    ], [ # erstatter 
+        sh:class dcat:Dataset ;
+        sh:path dct:replaces ;
+        sh:message "dct:replaces skal referere til en instans av dcat:Dataset"@nb ;
+        sh:severity sh:Violation
+    ], [ # erstattes av
+        sh:class dcat:Dataset ;
+        sh:path dct:isReplacedBy ;
+        sh:message "dct:isReplacedBy skal referere til en intans av dcat:Dataset"@nb ;
+        sh:severity sh:Violation
+    ], [ # forrige 
+        sh:maxCount 1 ;
+        sh:class dcat:Dataset ;
+        sh:path dcat:prev ;
+        sh:message "dcat:prev kan ha maks. én verdi som skal referere til en instans av dcat:Dataset"@nb ;
+        sh:severity sh:Violation
+    ], [ # frekvens
+#        sh:class dct:Frequency ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+        sh:path dct:accrualPeriodicity ;
+        sh:message "dct:accrualPeriodicity kan ha maks. én verdi som skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # har del
+        sh:class dcat:Dataset ;
+        sh:path dct:hasPart ;
+        sh:message "dct:hasPart skal referere til en instans av dcat:Dataset"@nb ;
+        sh:severity sh:Violation
+    ], [ # har kvalitetsnote
+        sh:class dqv:QualityAnnotation ;
+        sh:path dqv:hasQualityAnnotation ;
+        sh:message "dqv:hasQualityAnnotation skal referere til en instans av dqv:QualityAnnotation"@nb ;
+        sh:severity sh:Violation
+    ], [ # har måleresultat
+        sh:class dqv:QualityMeasurement ;
+        sh:path dqv:hasQualityMeasurement ;
+        sh:message "dqv:hasQualityMeasurement skal referere til en instans av dqv:QualityMeasurement"@nb ;
+        sh:severity sh:Violation
+    ], [ # har versjon
+        sh:class dcat:Dataset ;
+        sh:path dct:hasVersion ;
+        sh:message "dct:hasVersion skal referere til en instans av dcat:Dataset"@nb ;
+        sh:severity sh:Violation
+    ], [ # i samsvar med
+#        sh:class dct:Standard ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dct:conformsTo ;
+        sh:message "dct:conformsTo skal være en blank node eller IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # i serie
+        sh:class dcat:DatasetSeries ;
+        sh:path dcat:inSeries ;
+        sh:message "dcat:inSeries skal referere til en instans av dcat:DatasetSeries"@nb ;
+        sh:severity sh:Violation
+    ], [ # kilde 
         sh:class dcat:Dataset ;
         sh:path dct:source ;
+        sh:message "dct:source skal referere til en instans av dcat:Dataset"@nb ;
         sh:severity sh:Violation
-    ], [
+    ], [ # krever 
+        sh:class dcat:Dataset ;
+        sh:path dct:requires ;
+        sh:message "dct:requires skal referere til en instans av dcat:Dataset"@nb ;
+        sh:severity sh:Violation
+    ], [ # kvalifisert kreditering
+        sh:class prov:Attribution ;
+        sh:path prov:qualifiedAttribution ;
+        sh:message "prov:qualifiedAttribution skal referere til en instans av prov:Attribution"@nb ;
+        sh:severity sh:Violation
+    ], [ # kvalifisert relasjon
+        sh:class dcat:Relationship ;
+        sh:path dcat:qualifiedRelation ;
+        sh:message "dcat:qualifiedRelation skal referere til en instans av dcat:Relationship"@nb ;
+        sh:severity sh:Violation
+    ], [ # landingsside
+#        sh:class foaf:Document ;
+        sh:nodeKind sh:IRI ;
+        sh:path dcat:landingPage ;
+        sh:message "dcat:landingPage skal være en IRI"@nb ; 
+        sh:severity sh:Violation
+    ], [ # opphav
+        sh:class dct:ProvenanceStatement ;
+        sh:path dct:provenance ;
+        sh:message "dct:provenance skal referere til en instans av dct:ProvenanceStatement"@nb ;
+        sh:severity sh:Violation
+    ], [ # produsent
+#        sh:class foaf:Agent ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+        sh:path dct:creator ;
+        sh:message "dct:creator skal være en IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # refererer til 
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dct:references ;
+        sh:message "dct:references skal være blank node eller IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # relatert ressurs 
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dct:relation ;
+        sh:message "dct:relation skal være blank node eller IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # romlig oppløsning
         sh:datatype xsd:decimal ;
         sh:path dcat:spatialResolutionInMeters ;
+        sh:message "dcat:spatialResolutionInMeters skal være av type xsd:decimal"@nb ;
         sh:severity sh:Violation
-    ], [
+    ], [ # språk
+#        sh:class dct:LinguisticSystem ;
+        sh:nodeKind sh:IRI ;
+        sh:path dct:language ;
+        sh:message "dct:language skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # tidsoppløsning
         sh:datatype xsd:duration ;
         sh:path dcat:temporalResolution ;
+        sh:message "dcat:temporalResolution skal være av type xsd:duration"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class skos:Concept ;
-        sh:maxCount 1 ; # Norwegian extension: Added maxCount 1 (error in BRegDCAT-AP-Shacl)
+    ], [ # type
+#        sh:class skos:Concept ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ; 
         sh:path dct:type ;
+        sh:message "dct:type kan ha maks. én verdi som skal være IRI"@nb ;
         sh:severity sh:Violation
-    ], [
+    ], [ # utgivelsesdato
+        sh:maxCount 1 ;
+        sh:path dct:issued ;
+        sh:message "dct:issued kan ha maks. én verdi"@nb ;
+        sh:severity sh:Violation ;
+    ], [ # versjon 
         sh:maxCount 1 ;
         sh:nodeKind sh:Literal ;
         sh:path owl:versionInfo ;
+        sh:message "owl:versionInfo kan ha maks. én verdi som skal være Literal"@nb ;
         sh:severity sh:Violation
-    ], [
+    ], [ # versjonsnote 
         sh:nodeKind sh:Literal ;
         sh:path adms:versionNotes ;
-        sh:severity sh:Violation
-    ], [
-        sh:class prov:Activity ;
-        sh:path prov:wasGeneratedBy ;
-        sh:severity sh:Violation
-    ], [ # Norwegian extension: Added this property
-        sh:class skos:Concept ;
-        sh:path dct:subject ;
+        sh:message "adms:versionNotes skal være Literal"@nb ;
         sh:severity sh:Violation
     ] ;
     sh:targetClass dcat:Dataset .
 
-# Distribusjon (dcat:Distribution), with Norwegian extensions
+# Datasett serie (dcat:DatasetSeries)
+:DatasetSerie_Shape
+    a sh:NodeShape ;
+    rdfs:label "Dataset series"@en , "Datasett serie"@nb ;
+    sh:property [ # første
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:class dcat:Dataset ; 
+        sh:path dcat:first ;
+        sh:message "dcat:first skal ha én og bare én verdi som skal referere til en instans av dcat:Dataset"@nb ;
+        sh:severity sh:Violation ;
+    ], [ # siste 
+        sh:maxCount 1 ;
+        sh:class dcat:Dataset ; 
+        sh:path dcat:last ;
+        sh:message "dcat:last kan ha maks. én verdi som skal referere til en instans av dcat:Dataset"@nb ;
+        sh:severity sh:Violation ;
+    ] ;
+    sh:targetClass dcat:DatasetSeries .
+
+# Datatjeneste (dcat:DataService)
+:DataService_Shape
+    a sh:NodeShape ;
+    rdfs:label "Data Service"@en , "Datatjeneste"@nb ;
+    sh:property [ # endepunktURL
+        sh:maxCount 1 ; # Norwegian extension: added maxCount 1
+        sh:minCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dcat:endpointURL ;
+        sh:message "dcat:endpointURL skal ha én og bare én verdi som skal være blank node eller IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # identifikator
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:identifier ;
+        sh:message "dct:identifier skal ha minst én verdi som skal være Literal"@nb ;
+        sh:severity sh:Violation
+    ], [ # tittel
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:message "dct:title skal ha minst én verdi som skal være Literal"@nb ; 
+        sh:severity sh:Violation
+    ], [ # emneord
+        sh:nodeKind sh:Literal ;
+        sh:path dcat:keyword ; 
+        sh:message "dcat:keyword skal være Literal"@nb ;
+        sh:severity sh:Violation
+    ], [ # endepunktsbeskrivelse
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dcat:endpointDescription ;
+        sh:message "dcat:endpointDescription skal være blank node eller IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # format, Norwegian extension: Added dct:format
+#        sh:class dct:MediaTypeOrExtent ;
+        sh:nodeKind sh:IRI ;
+        sh:path dct:format ;
+        sh:message "dct:format skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ ## format, Norwegian extension, check Controlled Vocab for dct:format
+        sh:node :FileTypeRestriction ;
+        sh:nodeKind sh:IRI ;
+        sh:path dct:format ;
+        sh:message "dct:format skal være IRI"@nb ;
+        sh:severity sh:Violation
+     ], [ # kontaktpunkt 
+        sh:or (
+            [ sh:class vcard:Kind ]
+            [ sh:class vcard:Organization ] ) ;
+        sh:path dcat:contactPoint ;
+        sh:message "dcat:contactPoint skal referere til en instans av vcard:Kind eller vcard:Organization"@nb ;
+        sh:severity sh:Violation 
+     ], [ # tema 
+#        sh:class skos:Concept ;
+        sh:nodeKind sh:IRI ;
+        sh:path dcat:theme ;
+        sh:message "dcat:theme skal være IRI"@nb ;
+        sh:severity sh:Violation 
+     ], [ # tilgjengeliggjør datasett
+        sh:class dcat:Dataset ;
+        sh:path dcat:servesDataset ;
+        sh:message "dcat:servesDataset skal referere til en instans av dcat:Dataset"@nb ;
+        sh:severity sh:Violation
+    ], [ # utgiver
+        sh:minCount 1 ;
+#        sh:class foaf:Agent ;
+        sh:nodeKind sh:IRI ;
+        sh:path dct:publisher ;
+        sh:message "dct:publisher skal ha minst én verdi som skal være IRI"@nb ; 
+        sh:severity sh:Violation
+    ], [ # beskrivelse
+        sh:nodeKind sh:Literal ;
+        sh:path dct:description ;
+        sh:message "dct:description skal være Literal"@nb ;
+        sh:severity sh:Violation
+    ], [ # dokumentasjon
+#        sh:class foaf:Document ;
+        sh:nodeKind sh:IRI ;
+        sh:path foaf:page ;
+        sh:message "foaf:page skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # følger
+        sh:class cpsv:Rule ;
+        sh:path cpsv:follows ;
+        sh:message "cpsv:follows skal referere til en instans av cpsv:Rule"@nb ;
+        sh:severity sh:Violation
+    ], [ # i samsvar med 
+#        sh:class dct:Standard ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dct:conformsTo ;
+        sh:message "dct:conformsTo skal være blank node eller IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # landingsside  
+        sh:maxCount 1 ;
+#        sh:class foaf:Document ;
+        sh:nodeKind sh:IRI ;
+        sh:path dcat:landingPage ;
+        sh:message "dcat:landingPage kan ha maks. én verdi som skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # lisens 
+#        sh:class dct:LicenseDocument ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+        sh:path dct:license ;
+        sh:message "dct:license kan ha maks. én verdi som skal være IRI"@nb ;
+        sh:severity sh:Violation
+   ], [ # medietype, Norwegian extension: Added dcat:mediaType
+#        sh:class dct:MediaType ;
+        sh:nodeKind sh:IRI ;
+        sh:path dcat:mediaType ;
+        sh:message "dcat:mediaType skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # tilgangsrettigheter
+#        sh:class dct:RightsStatement ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+        sh:path dct:accessRights ;
+        sh:message "dct:accessRights kan ha maks. én verdi som skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # type
+        sh:maxCount 1 ;
+        sh:path dct:type ;
+#        sh:class skos:Concept ;
+        sh:nodeKind sh:IRI ;
+        sh:message "dct:type kan ha maks. én verdi som skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ];
+    sh:targetClass dcat:DataService .
+
+# Distribusjon (dcat:Distribution)
 :Distribution_Shape
     a sh:NodeShape ;
-    sh:name "Distribution"@en , "Distribusjon"@nb ;
-    sh:property [
+    rdfs:label "Distribution"@en , "Distribusjon"@nb ;
+    sh:property [ # tilgangsURL
         sh:minCount 1 ;
         sh:nodeKind sh:BlankNodeOrIRI;
         sh:path dcat:accessURL ;
+        sh:message "dcat:accessURL skal ha minst én verdi som skal være IRI"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class skos:Concept ;
-        sh:maxCount 1 ;
-        sh:path dcatap:availability ;
-        sh:severity sh:Violation
-    ], [
+    ], [ # beskrivelse
         sh:nodeKind sh:Literal ;
         sh:path dct:description ;
+        sh:message "dct:description skal være Literal"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class dct:MediaTypeOrExtent ;
+    ], [ # format
+#        sh:class dct:MediaTypeOrExtent ;
+        sh:nodeKind sh:IRI ;
         # sh:maxCount 1 ; # Norwegian extension 0..n
         sh:path dct:format ;
+        sh:message "dct:format skal være IRI"@nb ;
         sh:severity sh:Violation
-    ], [ # sjekker kun klasse her
-        sh:class dct:LicenseDocument ;
+    ], [ # lisens, sjekker kun klasse her
+#        sh:class dct:LicenseDocument ;
+        sh:nodeKind sh:IRI ;
 #        sh:maxCount 1 ;
         sh:path dct:license ;
+        sh:message "dct:license skal være IRI"@nb ;
         sh:severity sh:Violation ;
-        sh:message "Range: Det som dct:license peker på er ikke en instans av dct:LicenseDocument."@nb ;
-    ], [ # sjekker kun maks. antall her
+    ], [ # lisens, sjekker kun maks. antall her
 #        sh:class dct:LicenseDocument ;
+        sh:nodeKind sh:IRI ;
         sh:maxCount 1 ;
         sh:path dct:license ;
         sh:severity sh:Violation ;
-        sh:message "Multiplisitet: dct:license kan ha maks. 1 verdi."@nb ;
-    ], [ # sjekker kun min. antall her, fordi dct:license er anbefalt, warning hvis ikke med
+        sh:message "dct:license kan ha maks. én verdi som skal være IRI"@nb ;
+    ], [ # lisens, sjekker kun min. antall her, fordi dct:license er anbefalt, warning hvis ikke med
 #        sh:class dct:LicenseDocument ;
         sh:minCount 1 ;
         sh:path dct:license ;
         sh:severity sh:Warning ;
-        sh:message "Kravsnivå: Fant ingen lisens (dct:license). Lisens er anbefalt egenskap for Distribusjon."@nb ;
-    ], [
-        sh:class dcat:DataService ;
-        sh:path dcat:accessService ;
+        sh:message "Varsel: Fant ingen lisens (dct:license). Lisens er anbefalt egenskap for Distribusjon."@nb ;
+    ], [ # status 
+#        sh:class skos:Concept ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+        sh:path adms:status ;
+        sh:message "adms:status kan ha maks. én verdi som skal være IRI"@nb ;
         sh:severity sh:Violation
-    ], [
+    ], [ # tilgjengelighet
+#        sh:class skos:Concept ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+        sh:path dcatap:availability ;
+        sh:message "dcatap:availability kan ha maks. én verdi som skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # dokumentasjon 
+#        sh:class foaf:Document ;
+        sh:nodeKind sh:IRI ;
+        sh:path foaf:page ;
+        sh:message "foaf:page skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # endringsdato 
+        sh:maxCount 1 ;
+        sh:path dct:modified ;
+        sh:message "dct:modified kan ha maks. én verdi"@nb ;
+        sh:severity sh:Violation
+    ], [ # filstørrelse 
         sh:datatype xsd:decimal ;
         sh:maxCount 1 ;
         sh:path dcat:byteSize ;
+        sh:message "dcat:byteSize kan ha maks. én verdi som skal være av type xsd:decimal"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class spdx:Checksum ;
-        sh:maxCount 1 ;
-        sh:path spdx:checksum ;
+    ], [ # i samsvar med  
+#        sh:class dct:Standard ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dct:conformsTo ;
+        sh:message "dct:conformsTo skal være blank node eller IRI"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class dct:MediaType ;
+    ], [ # kompremeringsformat 
+#        sh:class dct:MediaType ;
+        sh:nodeKind sh:IRI ;
         sh:maxCount 1 ;
         sh:path dcat:compressFormat ;
+        sh:message "dcat:compressFormat kan ha maks. én verdi som skal være IRI"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class dct:Standard ;
-        sh:path dct:conformsTo ;
+    ], [ # medietype 
+#        sh:class dct:MediaType ;
+        sh:nodeKind sh:IRI ;
+        sh:path dcat:mediaType ;
+        sh:message "dcat:mediaType skal være IRI"@nb ;
         sh:severity sh:Violation
-    ], [
+    ], [ # nedlastsingslenke
         sh:nodeKind sh:BlankNodeOrIRI;
         sh:path dcat:downloadURL ;
+        sh:message "dcat:downloadURL skal være blank node eller IRI"@nb ; 
         sh:severity sh:Violation
-    ], [
+    ], [ # pakkeformat 
+#        sh:class dct:MediaType ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+        sh:path dcat:packageFormat ;
+        sh:message "dcat:packageFormat kan ha maks. én verdi som skal være IRI"@nb ; 
+        sh:severity sh:Violation
+    ], [ # policy
         sh:class odrl:Policy ;
         sh:maxCount 1 ;
         sh:path odrl:hasPolicy ;
+        sh:message "odrl:hasPolicy kan ha maks. én verdi som skal referere til en instans av odrl:Policy"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:maxCount 1 ;
-        sh:node :DateOrDateTimeDataType_Shape ;
-        sh:path dct:issued ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dct:LinguisticSystem ;
-        sh:path dct:language ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dct:MediaType ;
-        sh:maxCount 1 ;
-        sh:path dcat:mediaType ;
-        sh:severity sh:Violation
-    ], [
-        sh:maxCount 1 ;
-        sh:node :DateOrDateTimeDataType_Shape ;
-        sh:path dct:modified ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dct:MediaType ;
-        sh:maxCount 1 ;
-        sh:path dcat:packageFormat ;
-        sh:severity sh:Violation
-    ], [
-        sh:class foaf:Document ;
-        sh:path foaf:page ;
-        sh:severity sh:Violation
-    ], [
+    ], [ # rettigheter 
         sh:class dct:RightsStatement ;
         sh:maxCount 1 ;
         sh:path dct:rights ;
+        sh:message "dct:rights kan ha maks. én verdi som skal referere til en instans av dct:RightsStatement"@nb ;
         sh:severity sh:Violation
-    ], [
+    ], [ # romlig oppløsning
         sh:datatype xsd:decimal ;
         sh:path dcat:spatialResolutionInMeters ;
+        sh:message "dcat:spatialResolutionInMeters skal væer av type xsd:desimal"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class skos:Concept ;
+    ], [ # sjekksum 
+        sh:class spdx:Checksum ;
         sh:maxCount 1 ;
-        sh:path adms:status ;
+        sh:path spdx:checksum ;
+        sh:message "spdx:checksum kan ha maks. én verdi som skal referere til en instans av spdx:Checksum"@nb ;
         sh:severity sh:Violation
-    ], [
+    ], [ # språk
+#        sh:class dct:LinguisticSystem ;
+        sh:nodeKind sh:IRI ;
+        sh:path dct:language ;
+        sh:message "dct:language skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # tidsoppløsning 
         sh:datatype xsd:duration ;
         sh:path dcat:temporalResolution ;
+        sh:message "dcat:temporalResolution skal være av type xsd:duration"@nb ;
         sh:severity sh:Violation
-    ], [
+    ], [ # tilgangstjeneste 
+        sh:class dcat:DataService ;
+        sh:path dcat:accessService ;
+        sh:message "dcat:acessService skal referere til en instans av dcat:DataService"@nb ;
+        sh:severity sh:Violation
+    ], [ # tittel 
         sh:nodeKind sh:Literal ;
         sh:path dct:title ;
+        sh:message "dct:title skal være Literal"@nb ;
+        sh:severity sh:Violation
+    ], [ # utgivelsesdato 
+        sh:maxCount 1 ;
+        sh:path dct:issued ;
+        sh:message "dct:issued kan ha maks. én verdi"@nb ;
         sh:severity sh:Violation
     ] ;
     sh:targetClass dcat:Distribution .
 
-# Dokument (foaf:Document), the whole class is a Norwegian extension
+# Dokument (foaf:Document)
 :Document_Shape
     a sh:NodeShape ;
-    sh:name "Document"@en , "Dokument"@nb ;
-    sh:property [
-        sh:datatype dct:LinguisticSystem ;
+    rdfs:label "Document"@en , "Dokument"@nb ;
+    sh:property [ # språk
+#        sh:datatype dct:LinguisticSystem ;
+        sh:nodeKind sh:IRI ;
         sh:maxCount 1 ;
         sh:path dct:language ;
+        sh:message "dct:language kan ha maks. én verdi som skal være IRI"@nb ;
         sh:severity sh:Violation
-    ], [
+    ], [ # tittel
         sh:nodeKind sh:Literal ;
         sh:path dct:title ;
+        sh:message "dct:title skal være Literal"@nb ;
         sh:severity sh:Violation
     ] ;
     sh:targetClass foaf:Document .
 
-# Identifikator (adms:Identifier),
-# added the Norwegian sh:name
-# changed to sh:targetObjectsOf
+# Identifikator (adms:Identifier)
 :Identifier_Shape
     a sh:NodeShape ;
-    sh:name "Identifier"@en , "Identifikator"@nb ;
+    rdfs:label "Identifier"@en , "Identifikator"@nb ;
     sh:property [
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:path skos:notation ;
+        sh:message "skos:notation skal ha én og bare én verd"@nb ;
         sh:severity sh:Violation
     ] ;
     # sh:targetClass adms:Identifier ;
     sh:targetObjectsOf adms:identifier ;
     .
 
-# Regulativ ressurs (eli:LegalResource), only added the Norwegian sh:name
-:LegalResource_Shape
-    a sh:NodeShape ;
-    sh:name "Legal Resource"@en , "Regulativ ressurs"@nb ;
-    sh:property [
-        sh:minCount 1 ;
-        sh:class eli:ResourceType ;
-        sh:path dct:type ;
-        sh:severity sh:Violation
-    ], [
-        sh:nodeKind sh:Literal ;
-        sh:path dct:description ;
-        sh:severity sh:Violation
-    ], [
-        sh:nodeKind sh:Literal ;
-        sh:path dct:identifier ;
-        sh:severity sh:Violation
-    ], [
-        sh:nodeKind sh:BlankNodeOrIRI;
-        sh:path rdfs:seeAlso ;
-        sh:severity sh:Violation
-    ], [
-        sh:class eli:LegalResource ;
-        sh:path dct:relation ;
-        sh:severity sh:Violation
-    ] ;
-    sh:targetClass eli:LegalResource .
-
-# Lisensdokument (dct:LicenseDocument), only added the Norwegian sh:name
-:LicenseDocument_Shape
-    a sh:NodeShape ;
-    sh:name "License Document"@en , "Lisensdokument"@nb ;
-    sh:property [
-        sh:class skos:Concept ;
-        sh:path dct:type ;
-        sh:severity sh:Violation
-    ] ;
-    sh:targetClass dct:LicenseDocument .
-
-# Lokasjon (dct:Location), only added the Norwegian sh:name
-:Location_Shape
-    a sh:NodeShape ;
-    sh:name "Location"@en , "Lokasjon"@nb ;
-    sh:property [
-        sh:maxCount 1 ;
-        sh:nodeKind sh:Literal ;
-        sh:path dcat:bbox ;
-        sh:severity sh:Violation
-    ], [
-        sh:maxCount 1 ;
-        sh:nodeKind sh:Literal ;
-        sh:path dcat:centroid ;
-        sh:severity sh:Violation
-    ], [
-        sh:maxCount 1 ;
-        sh:nodeKind sh:Literal ;
-        sh:path locn:geometry ;
-        sh:severity sh:Violation
-    ] ;
-    sh:targetClass dct:Location .
-
-# Tidsrom (dct:PeriodOfTime), only added the Norwegian sh:name
-:PeriodOfTime_Shape
-    a sh:NodeShape ;
-    sh:name "Period of Time"@en , "Tidsrom"@nb ;
-    sh:property [
-        sh:maxCount 1 ;
-        sh:path dcat:endDate ;
-        sh:severity sh:Violation ;
-        sh:node :DateOrDateTimeDataType_Shape
-    ], [
-        sh:class time:Instant ;
-        sh:maxCount 1 ;
-        sh:path time:hasBeginning ;
-        sh:severity sh:Violation
-    ], [
-        sh:class time:Instant ;
-        sh:maxCount 1 ;
-        sh:path time:hasEnd ;
-        sh:severity sh:Violation
-    ], [
-        sh:maxCount 1 ;
-        sh:path dcat:startDate ;
-        sh:severity sh:Violation ;
-        sh:node :DateOrDateTimeDataType_Shape
-    ] ;
-    sh:targetClass dct:PeriodOfTime .
-
-# Offentlig organisasjon (cv:PublicOrganisation), with Norwegian extensions
-:PublicOrganization_Shape
-    a sh:NodeShape ;
-    sh:name "Public Organisation"@en , "Offentlig organisasjon"@nb ;
-    sh:property [
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
-        sh:nodeKind sh:Literal ;
-        sh:path dct:identifier ;
-        sh:severity sh:Violation
-    ], [
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
-        sh:nodeKind sh:Literal ;
-        sh:path dct:title ;
-        sh:severity sh:Violation
-    ], [
-        sh:nodeKind sh:Literal ;
-        sh:minCount 1 ;
-        sh:path skos:prefLabel ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dct:Location ;
-        sh:minCount 1 ;
-        sh:path dct:spatial ;
-        sh:severity sh:Violation
-    ], [
-        sh:class locn:Address ;
-        sh:path locn:address ;
-        sh:severity sh:Violation
-    ], [
-        sh:class skos:Concept ;
-        sh:path org:classification ;
-        sh:severity sh:Violation
-    ], [
-        sh:class foaf:Document ;
-        # Norwegian extension: deleted maxCount 1
-        # sh:maxCount 1 ;
-        sh:path foaf:homepage ;
-        sh:severity sh:Violation
-    ] ;
-    sh:targetClass cv:PublicOrganisation .
-
-# Offentlig tjeneste (cpsv:PublicService), with Norwegian extensions
-:PublicRegistryService_Shape
-    a sh:NodeShape ;
-    sh:name "Public Registry Service"@en , "Offentlig tjeneste"@nb ;
-    sh:property [
-        sh:minCount 1 ;
-        sh:nodeKind sh:Literal ;
-        sh:path dct:description ;
-        sh:severity sh:Violation
-    ], [
-        sh:minCount 1 ;
-        sh:class cv:PublicOrganisation ;
-        sh:path cv:hasCompetentAuthority ;
-        sh:severity sh:Violation
-    ], [
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
-        sh:nodeKind sh:Literal ;
-        sh:path dct:identifier ;
-        sh:severity sh:Violation
-    ], [
-        sh:minCount 1 ;
-        sh:nodeKind sh:Literal ;
-        sh:path dct:title ;
-        sh:severity sh:Violation
-    ], [
-        sh:class cpsv:PublicService ;
-        sh:path dct:hasPart ;
-        sh:severity sh:Violation
-    ], [
-        sh:class foaf:Document ;
-        # Norwegian extension: deleted maxCount 1
-        # sh:maxCount 1 ;
-        sh:path foaf:homepage ;
-        sh:severity sh:Violation
-    ], [
-        sh:class cpsv:PublicService ;
-        sh:path dct:isPartOf ;
-        sh:severity sh:Violation
-    ], [
-        sh:node :DcatResource_Shape ;
-        sh:path cpsv:produces ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dct:Location ;
-        sh:path dct:spatial ;
-        sh:severity sh:Violation
-    ], [
-        sh:class skos:Concept ;
-        sh:maxCount 1 ;
-        sh:path adms:status ;
-        sh:severity sh:Violation
-    ], [
-        sh:class skos:Concept ;
-        sh:path cv:thematicArea ;
-        sh:severity sh:Violation
-    ], [
-        sh:class skos:Concept ;
-        sh:path dct:type ;
-        sh:severity sh:Violation
-    ], [
-        sh:class cpsv:Rule ;
-        sh:path cpsv:follows ;
-        sh:severity sh:Violation
-    ], [
-        sh:class schema:ContactPoint ;
-        sh:path cv:hasContactPoint ;
-        sh:severity sh:Violation
-    ], [
-        sh:class eli:LegalResource ;
-        sh:path cv:hasLegalResouce ;
-        sh:severity sh:Violation
-    ] ;
-    sh:targetClass cpsv:PublicService .
-
-# Katalog (dcat:Catalog), only with the Norwegian sh:name
+# Katalog (dcat:Catalog)
 :Catalog_Shape
     a sh:NodeShape ;
-    sh:name "Registry Catalogue"@en , "Katalog"@nb ;
-    sh:property [
+    rdfs:label "Registry Catalogue"@en , "Katalog"@nb ;
+    sh:property [ # beskrivelse 
         sh:minCount 1 ;
         sh:nodeKind sh:Literal ;
         sh:path dct:description ;
+        sh:message "dct:description skal ha minst én verdi som skal være Literal"@nb ;
         sh:severity sh:Violation
-    ], [
+    ], [ # identifikator
         sh:nodeKind sh:Literal ;
         sh:maxCount 1 ;
         sh:minCount 1 ;
         sh:path dct:identifier ;
+        sh:message "dct:identifier skal ha én og bare én verdi som skal være Literal"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class foaf:Agent ;
+    ], [ # tittel
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:message "dct:title skal ha minst én verdi som skal være Literal"@nb ;
+        sh:severity sh:Violation
+    ], [ # utgiver
+#        sh:class foaf:Agent ;
+        sh:nodeKind sh:IRI ;
         sh:maxCount 1 ;
         sh:minCount 1 ;
         sh:path dct:publisher ;
+        sh:message "dct:publisher skal ha én og bare én verdi som skal være IRI"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:minCount 1 ;
-        sh:nodeKind sh:Literal ;
-        sh:path dct:title ;
+    ], [ # datasett
+        sh:or (
+            [ sh:class dcat:Dataset ]
+            [ sh:class dcat:DatasetSeries ]
+        ) ; 
+        sh:path dcat:dataset ;
+        sh:message "dcat:dataset skal referere til en instans av dcat:Dataset eller dcat:DatasetSeries"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class dct:Frequency ;
+    ], [ # dekningsområde 
+#        sh:class dct:Location ;
+        sh:nodeKind sh:IRI ;
+        sh:path dct:spatial ;
+        sh:message "dct:spatial skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # endringsdato 
+        sh:maxCount 1 ;
+        sh:path dct:modified ;
+        sh:message "dct:modified kan ha maks. én verdi"@nb ;
+        sh:severity sh:Violation
+    ], [ # frekvens 
+#        sh:class dct:Frequency ;
+        sh:nodeKind sh:IRI ;
         sh:maxCount 1 ;
         sh:path dct:accrualPeriodicity ;
+        sh:message "dct:accrualPeriodicity kan ha maks. én verdi som skal være IRI"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class dcat:Dataset ;
-        sh:path dcat:dataset ;
-        sh:severity sh:Violation
-    ],  [
-        sh:class foaf:Document ;
+    ],  [ # hjemmeside 
+#        sh:class foaf:Document ;
+        sh:nodeKind sh:IRI ;
         sh:maxCount 1 ;
         sh:path foaf:homepage ;
+        sh:message "foaf:homepage kan ha maks. én verdi som skal være IRI"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:maxCount 1 ;
-        sh:node :DateOrDateTimeDataType_Shape ;
-        sh:path dct:issued ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dct:LinguisticSystem ;
-        sh:path dct:language ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dct:LicenseDocument ;
+    ], [ # lisens 
+#        sh:class dct:LicenseDocument ;
+        sh:nodeKind sh:IRI ;
         sh:maxCount 1 ;
         sh:path dct:license ;
+        sh:message "dct:license kan ha maks. én verdi som skal være IRI"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:maxCount 1 ;
-        sh:node :DateOrDateTimeDataType_Shape ;
-        sh:path dct:modified ;
-        sh:severity sh:Violation
-    ], [
+    ], [ # opphav 
         sh:class dct:ProvenanceStatement ;
         sh:path dct:provenance ;
+        sh:message "dct:provenance skal referere til en instans av dct:ProvenanceStatement"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class dct:Location ;
-        sh:path dct:spatial ;
+    ], [ # språk 
+#        sh:class dct:LinguisticSystem ;
+        sh:nodeKind sh:IRI ;
+        sh:path dct:language ;
+        sh:message "dct:language skal være IRI"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class skos:ConceptScheme ;
+    ], [ # temaer 
+#        sh:class skos:ConceptScheme ;
+        sh:nodeKind sh:IRI ;
         sh:path dcat:themeTaxonomy ;
+        sh:message "dcat:themeTaxonomy skal være IRI"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class dcat:Catalog ;
-        sh:path dcat:catalog ;
-        sh:severity sh:Violation
-    ], [
-        sh:class foaf:Agent ;
+    ], [ # utgivelsesdato 
         sh:maxCount 1 ;
-        sh:path dct:creator ;
+        sh:path dct:issued ;
+        sh:message "dct:issued kan ha maks. én verdi"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class dcat:Catalog ;
-        sh:path dct:hasPart ;
+    ], [ # datatjeneste 
+        sh:class dcat:DataService ;
+        sh:path dcat:service ;
+        sh:message "dcat:service skal referere til en instans av dcat:DataServcie"@nb ;
         sh:severity sh:Violation
-    ], [
+    ], [ # er del av 
         sh:class dcat:Catalog ;
         sh:maxCount 1 ;
         sh:path dct:isPartOf ;
+        sh:message "dct:isPartOf kan ha maks. én verdi som skal referere til en instnas av dcat:Catalog"@nb ;
         sh:severity sh:Violation
-    ], [
+    ], [ # har del 
+        sh:class dcat:Catalog ;
+        sh:path dct:hasPart ;
+        sh:message "dct:hasPart skal referere til en instnas av dcat:Catalog"@nb ;
+        sh:severity sh:Violation
+    ], [ # katalog 
+        sh:class dcat:Catalog ;
+        sh:path dcat:catalog ;
+        sh:message "dcat:catalog skal referere til en instans av dcat:Catalog"@nb ;
+        sh:severity sh:Violation
+    ], [ # katalogpost 
         sh:class dcat:CatalogRecord ;
         sh:path dcat:record ;
+        sh:message "dcat:record skal referere til en instans av dcat:CatalogRecord"@nb ;
         sh:severity sh:Violation
-    ], [
+    ], [ # produsent 
+#        sh:class foaf:Agent ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+        sh:path dct:creator ;
+        sh:message "dct:creator kan ha maks. én verdi som skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # rettigheter
         sh:class dct:RightsStatement ;
         sh:maxCount 1 ;
         sh:path dct:rights ;
-        sh:severity sh:Violation
-    ], [
-        sh:class dcat:DataService ;
-        sh:path dcat:service ;
+        sh:message "dct:rights kan ha maks. én verdi som skal referere til en instans av dct:RightsStatement"@nb ;
         sh:severity sh:Violation
     ] ;
     sh:targetClass dcat:Catalog .
 
-# Relasjon (dcat:Relationship), only with the Norwegian sh:name
-:Relationship_Shape
+# Katalogpost (dcat:CatalogRecord)
+:CatalogRecord_Shape
     a sh:NodeShape ;
-    sh:name "Relationship"@en , "Relasjon"@nb ;
-    sh:property [
+    rdfs:label "Catalogue Record"@en , "Katalogpost"@nb ;
+    sh:property [ # endringsdato
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:path dct:modified ;
+        sh:severity sh:Violation ;
+        sh:message "dct:modified skal ha én og bare én verdi"@nb ;
+    ], [ # primærtema 
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
         sh:node :DcatResource_Shape ;
-        sh:minCount 1 ;
-        sh:path dct:relation ;
+        sh:path foaf:primaryTopic ;
+        sh:message "foaf:primaryTopic skal ha én og bare én verdi"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:minCount 1 ;
-        sh:class dcat:Role ;
-        sh:path dcat:hadRole ;
+    ], [ # i samsvar med  
+#        sh:class dct:Standard ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:maxCount 1 ;
+        sh:path dct:conformsTo ;
+        sh:message "dct:conformsTo kan ha maks. én verdi som skal være blank node eller IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # status 
+#        sh:class skos:Concept ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+        sh:path adms:status ;
+        sh:message "adms:status kan ha maks. én verdi som skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # utgivelsesdato 
+        sh:maxCount 1 ;
+        sh:path dct:issued ;
+        sh:message "dct:issued kan ha maks. én verdi"@nb ;
+        sh:severity sh:Violation
+    ], [ # beskrivelse 
+        sh:nodeKind sh:Literal ;
+        sh:path dct:description ;
+        sh:message "dct:description skal være Literal"@nb ;
+        sh:severity sh:Violation
+    ], [ # kilde 
+        sh:class dcat:CatalogRecord ;
+        sh:maxCount 1 ;
+        sh:path dct:source ;
+        sh:message "dct:source kan ha maks. én verdi som skal referere til en instans av dcat:CatalogRecord"@nb ;
+        sh:severity sh:Violation
+    ], [ # språk 
+#        sh:class dct:LinguisticSystem ;
+        sh:nodeKind sh:IRI ;
+        sh:path dct:language ;
+        sh:message "dct:language skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # tittel 
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:message "dct:title skal være Literal"@nb ;
         sh:severity sh:Violation
     ] ;
-    sh:targetClass dcat:Relationship .
+    sh:targetClass dcat:CatalogRecord .
 
-# Regel (cpsv:Rule), only with the Norwegian sh:name
-:Rule_Shape
+# Lisensdokument (dct:LicenseDocument)
+:LicenseDocument_Shape
     a sh:NodeShape ;
-    sh:name "Rule"@en , "Regel"@nb ;
-    sh:property [
+    rdfs:label "License Document"@en , "Lisensdokument"@nb ;
+    sh:property [ # lisenstype 
+#        sh:class skos:Concept ;
+        sh:nodeKind sh:IRI ;
+        sh:path dct:type ;
+        sh:message "dct:type skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dct:LicenseDocument .
+
+# Lokasjon (dct:Location)
+:Location_Shape
+    a sh:NodeShape ;
+    rdfs:label "Location"@en , "Lokasjon"@nb ;
+    sh:property [ # område 
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dcat:bbox ;
+        sh:message "dcat:bbox kan ha maks. én verdi som skal være Literal"@nb ;
+        sh:severity sh:Violation
+    ], [ # geografisk midtpunkt
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dcat:centroid ;
+        sh:message "dcat:centroid kan ha maks. én verdi som skal være Literal"@nb ;
+        sh:severity sh:Violation
+    ], [ # geometri
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path locn:geometry ;
+        sh:message "locn:geometry kan ha maks. én verdi som skal være Literal"@nb ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dct:Location .
+
+# Offentlig organisasjon (cv:PublicOrganisation)
+:PublicOrganization_Shape
+    a sh:NodeShape ;
+    rdfs:label "Public Organisation"@en , "Offentlig organisasjon"@nb ;
+    sh:property [ # dekningsområde
+#        sh:class dct:Location ;
+        sh:nodeKind sh:IRI ;
+        sh:minCount 1 ;
+        sh:path dct:spatial ;
+        sh:message "dct:spatial skal ha minst én verdi som skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # foretrukket navn
+        sh:nodeKind sh:Literal ;
+        sh:minCount 1 ;
+        sh:path skos:prefLabel ;
+        sh:message "skos:prefLabel skal ha minst én verdi som skal være Literal"@nb ;
+        sh:severity sh:Violation
+    ], [ # identifikator
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:identifier ;
+        sh:message "dct:identifier skal ha én og bare én verdi som skal være Literal"@nb ;
+        sh:severity sh:Violation
+    ], [  # navn
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:message "dct:title skal ha én og bare én verdi som skal være Literal"@nb ;
+        sh:severity sh:Violation
+    ], [ # adresse
+        sh:class locn:Address ;
+        sh:path locn:address ;
+        sh:message "locn:address skal referere til en instans av locn:Address"@nb ;
+        sh:severity sh:Violation
+    ], [ # hjemmeside
+#        sh:class foaf:Document ;
+        sh:nodeKind sh:IRI ;
+        # Norwegian extension: deleted maxCount 1
+        # sh:maxCount 1 ;
+        sh:path foaf:homepage ;
+        sh:message "foaf:homepage skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # klassifisering
+#        sh:class skos:Concept ;
+        sh:nodeKind sh:IRI ;
+        sh:path org:classification ;
+        sh:message "org:classification skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass cv:PublicOrganisation .
+
+# Offentlig tjeneste (cpsv:PublicService)
+:PublicRegistryService_Shape
+    a sh:NodeShape ;
+    rdfs:label "Public Registry Service"@en , "Offentlig tjeneste"@nb ;
+    sh:property [ # beskrivelse 
         sh:minCount 1 ;
         sh:nodeKind sh:Literal ;
         sh:path dct:description ;
+        sh:message "dct:description skal ha minst én verdi som skal være Literal"@nb ;
         sh:severity sh:Violation
-    ], [
+    ], [ # har kompetent organ 
+        sh:minCount 1 ;
+        sh:class cv:PublicOrganisation ;
+        sh:path cv:hasCompetentAuthority ;
+        sh:message "cv:hasCompetentAuthority skal ha minst én verdi som skal referere til en instans av cv:PublicOrganisation"@nb ;
+        sh:severity sh:Violation
+    ], [ # identifikator 
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:identifier ;
+        sh:message "dct:identifier skal ha én og bare én verdi som skal være Literal"@nb ;
+        sh:severity sh:Violation
+    ], [ # tittel
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:message "dct:title skal ha minst én verdi som skal være Literal"@nb ;
+        sh:severity sh:Violation
+    ], [ # dekningsområde 
+#        sh:class dct:Location ;
+        sh:nodeKind sh:IRI ;
+        sh:path dct:spatial ;
+        sh:message "dct:spatial skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # er del av
+        sh:class cpsv:PublicService ;
+        sh:path dct:isPartOf ;
+        sh:message "dct:isPartOf skal referere til en instans av cpsv:PublicService"@nb ;
+        sh:severity sh:Violation
+    ], [ # har del
+        sh:class cpsv:PublicService ;
+        sh:path dct:hasPart ;
+        sh:message "dct:hasPart skal referere til en instans av cpsv:PublicService"@nb ;
+        sh:severity sh:Violation
+    ], [ # hjemmeside 
+#        sh:class foaf:Document ;
+        sh:nodeKind sh:IRI ;
+        # Norwegian extension: deleted maxCount 1
+        # sh:maxCount 1 ;
+        sh:path foaf:homepage ;
+        sh:message "foaf:homepage skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # produserer 
+        sh:node :DcatResource_Shape ;
+        sh:path cpsv:produces ;
+        sh:severity sh:Violation
+    ], [ # status
+#        sh:class skos:Concept ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+        sh:path adms:status ;
+        sh:message "adms:status kan ha maks. én verdi som skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # temaområde 
+#        sh:class skos:Concept ;
+        sh:nodeKind sh:IRI ;
+        sh:path cv:thematicArea ;
+        sh:message "cv:thematicArea skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # type 
+#        sh:class skos:Concept ;
+        sh:nodeKind sh:IRI ;
+        sh:path dct:type ;
+        sh:message "dct:type skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # følger 
+        sh:class cpsv:Rule ;
+        sh:path cpsv:follows ;
+        sh:message "cpsv:follows skal referere til en instans av cpsv:Rule"@nb ;
+        sh:severity sh:Violation
+    ], [ # har kontaktpunkt
+        sh:class schema:ContactPoint ;
+        sh:path cv:hasContactPoint ;
+        sh:message "cv:hasContactPoint skal referere til en instans av schema:ContactPoint"@nb ;
+        sh:severity sh:Violation
+    ], [ # har regulativ ressurs
+        sh:class eli:LegalResource ;
+        sh:path cv:hasLegalResouce ;
+        sh:message "cv:hasLegalResource skal referere til en instans av eli:LegalResource"@nb ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass cpsv:PublicService .
+
+# Regel (cpsv:Rule)
+:Rule_Shape
+    a sh:NodeShape ;
+    rdfs:label "Rule"@en , "Regel"@nb ;
+    sh:property [ # beskrivelse
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:description ;
+        sh:message "dct:description skal ha minst én verdi som skal være Literal"@nb ;
+        sh:severity sh:Violation
+    ], [ # identifikator
         sh:nodeKind sh:Literal ;
         sh:maxCount 1 ;
         sh:minCount 1 ;
         sh:path dct:identifier ;
+        sh:message "dct:identifier skal ha én og bare én verdi om skal være Literal"@nb ; 
         sh:severity sh:Violation
-    ], [
+    ], [ # tittel
         sh:minCount 1 ;
         sh:nodeKind sh:Literal ;
         sh:path dct:title ;
+        sh:message "dct:title skal ha minst én verdi som skal være Literal"@nb ;
         sh:severity sh:Violation
-    ], [
+    ], [ # implementerer
         sh:class eli:LegalResource ;
         sh:path cpsv:implements ;
+        sh:message "cpsv:implements skal referere til en instans av eli:LegalResource"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:class dct:LinguisticSystem ;
+    ], [ # språk
+#        sh:class dct:LinguisticSystem ;
+        sh:nodeKind sh:IRI ;
         sh:path dct:language ;
+        sh:message "dct:language skal være IRI"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:minCount 1 ;
-        sh:class skos:Concept ;
+    ], [ # type 
+#        sh:class skos:Concept ;
+        sh:nodeKind sh:IRI ;
         sh:path dct:type ;
+        sh:message "dct:type skal være IRI"@nb ;
         sh:severity sh:Violation
     ] ;
     sh:targetClass cpsv:Rule .
 
-# Standard (dct:Standard), the whole class is an Norwegian extensions
+# Regulativ ressurs (eli:LegalResource)
+:LegalResource_Shape
+    a sh:NodeShape ;
+    rdfs:label "Legal Resource"@en , "Regulativ ressurs"@nb ;
+    sh:property [ # type
+        sh:minCount 1 ;
+#        sh:class eli:ResourceType ;
+        sh:nodeKind sh:IRI ;
+        sh:path dct:type ;
+        sh:message "dct:type skal være IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # beskrivelse
+        sh:nodeKind sh:Literal ;
+        sh:path dct:description ;
+        sh:message "dct:description skal være Literal"@nb ;
+        sh:severity sh:Violation
+    ], [ # identifikator
+        sh:nodeKind sh:Literal ;
+        sh:path dct:identifier ;
+        sh:message "dct:identifier skal være Literal"@nb ;
+        sh:severity sh:Violation
+    ], [ # referanse
+        sh:nodeKind sh:BlankNodeOrIRI;
+        sh:path rdfs:seeAlso ;
+        sh:message "rdfs:seeAlso skal være blank node eller IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # relatert regulativ ressurs
+        sh:class eli:LegalResource ;
+        sh:path dct:relation ;
+        sh:message "dct:relation skal referere til en instans av eli:LegalResource"@nb ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass eli:LegalResource .
+
+# Relasjon (dcat:Relationship)
+:Relationship_Shape
+    a sh:NodeShape ;
+    rdfs:label "Relationship"@en , "Relasjon"@nb ;
+    sh:property [ # relasjon
+        sh:node :DcatResource_Shape ;
+        sh:minCount 1 ;
+        sh:path dct:relation ;
+        sh:message "dct:relation skal ha minst én verdi"@nb ;
+        sh:severity sh:Violation
+    ], [ # rolle
+        sh:minCount 1 ;
+        sh:class dcat:Role ;
+        sh:path dcat:hadRole ;
+        sh:message "dcat:hadRole skal ha minst én verdi som skal referere til en instans av dcat:Role"@nb ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dcat:Relationship .
+
+# Sjekksum (spdx:Checksum)
+:Checksum_Shape
+    a sh:NodeShape ;
+    rdfs:label "Checksum"@en , "Sjekksum"@nb ;
+    sh:property [ # algoritme
+        sh:hasValue spdx:checksumAlgorithm_sha1 ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:path spdx:algorithm ;
+        sh:message "spdx:algorithm skal ha én og bare én vedi som skal være spdx:checksumAlgorithm_sha1"@nb ;
+        sh:severity sh:Violation
+    ], [ # sjekksumverdi
+        sh:datatype xsd:hexBinary ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:path spdx:checksumValue ;
+        sh:message "spdx:checksumValue skal ha én og bare én verdi som skal være av type xsd:hexBinary"@nb ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass spdx:Checksum .
+
+# Standard (dct:Standard)
 :Standard_Shape
     a sh:NodeShape ;
-    sh:name "Standard"@en , "Standard"@nb ;
-    sh:property [
+    rdfs:label "Standard"@en , "Standard"@nb ;
+    sh:property [ # har tittel
         sh:minCount 1;
         sh:nodeKind sh:Literal ;
         sh:path dct:title ;
+        sh:message "dct:title skal ha minst én verdi som skal være Literal"@nb ;
         sh:severity sh:Violation
-    ], [
+   ], [ # har referanse
+        sh:nodeKind sh:BlankNodeOrIRI;
+        sh:path rdfs:seeAlso ;
+        sh:message "rdfs:seeAlso skal være blank node eller IRI"@nb ;
+        sh:severity sh:Violation
+    ], [ # har versjonsnummer
         sh:maxCount 1 ;
         sh:nodeKind sh:Literal ;
         sh:path owl:versionInfo ;
+        sh:message "owl:versionInfo kan ha maks. én verdi som skal være Literal"@nb ;
         sh:severity sh:Violation
-    ], [
-        sh:nodeKind sh:BlankNodeOrIRI;
-        sh:path rdfs:seeAlso ;
-        sh:severity sh:Violation
-    ] ;
+     ] ;
     sh:targetObjectsOf dct:conformsTo ;
  .
 
-# Tematisk skjema (skos:ConceptScheme), only sh:names
-:CategoryScheme_Shape
+# Tema (skos:Concept)
+# Ikke sjekk, fordi det skal velges fra et kontrollert vokab
+# :Category_Shape
+#     a sh:NodeShape ;
+#     rdfs:label "Theme"@en , "Tema"@nb ;
+#    sh:property [ # foretrukket tittel
+#        sh:minCount 1 ;
+#         sh:nodeKind sh:Literal ;
+#         sh:path skos:prefLabel ;
+#         sh:severity sh:Violation
+#     ] ;
+#    sh:targetClass skos:Concept .
+
+# Tematisk skjema (skos:ConceptScheme)
+# Ikke sjekk, fordi det skal velges fra et kontrollert vokab
+# :CategoryScheme_Shape
+#     a sh:NodeShape ;
+#     rdfs:label "Thematic Scheme"@en , "Tematisk skjema"@nb ;
+#     sh:property [ # tittel
+#         sh:minCount 1 ;
+#         sh:nodeKind sh:Literal ;
+#         sh:path dct:title ;
+#         sh:severity sh:Violation
+#     ] ;
+#     sh:targetClass skos:ConceptScheme .
+
+# Tidsrom (dct:PeriodOfTime)
+:PeriodOfTime_Shape
     a sh:NodeShape ;
-    # Changed the English sh:name - typo of BRegDCAT-AP-SHACL
-    sh:name "Thematic Scheme"@en , "Tematisk skjema"@nb ;
-    sh:property [
-        sh:minCount 1 ;
-        sh:nodeKind sh:Literal ;
-        sh:path dct:title ;
+    rdfs:label "Period of Time"@en , "Tidsrom"@nb ;
+    sh:property [ # sluttdato/tid, kardinalitet
+        sh:maxCount 1 ;
+        sh:path dcat:endDate ;
+        sh:severity sh:Violation ;
+        sh:message "dcat:endData kan ha maks. én verdi"@nb ;
+    ], [ # sluttdato/tid, datatype
+        sh:or ( [sh:datatype xsd:date]  [sh:datatype xsd:dateTime]  );        
+        sh:path dcat:endDate ;
+        sh:severity sh:Violation ;
+        sh:message "dcat:endDate skal være av type xsd:date eller xsd:dateTime"@nb ;
+    ] , [ # startdato/tid
+        sh:maxCount 1 ;
+        sh:path dcat:startDate ;
+        sh:severity sh:Violation ;
+        sh:message "dcat:startDate kan ha maks. én verdi"@nb ;
+    ], [ # startdato/tid, datatype
+        sh:or ( [sh:datatype xsd:date]  [sh:datatype xsd:dateTime]  );        
+        sh:path dcat:startDate ;
+        sh:severity sh:Violation ;
+        sh:message "dcat:startDate skal være av type xsd:date eller xsd:dateTime"@nb ;
+    ] ,[ # begynnelse
+        sh:class time:Instant ;
+        sh:maxCount 1 ;
+        sh:path time:hasBeginning ;
+        sh:message "time:hasBeginning kan ha maks. én verdi"@nb ;
+        sh:severity sh:Violation
+    ], [ # slutt
+        sh:class time:Instant ;
+        sh:maxCount 1 ;
+        sh:path time:hasEnd ;
+        sh:message "time:hasEnd kan ha maks. én verdi"@nb ;
         sh:severity sh:Violation
     ] ;
-    sh:targetClass skos:ConceptScheme .
+    sh:targetClass dct:PeriodOfTime .
 
-# Tema (skos:Concept), only the sh:names
-:Category_Shape
+# datatype xsd:date / xsd:dateTime 
+
+:DateTime_Shape # check xsd:date / xsd:dateTime
     a sh:NodeShape ;
-    sh:name "Theme"@en , "Tema"@nb ;
+    rdfs:comment "Check if the data type is xsd:date or xsd:dateTime" ;
     sh:property [
-        sh:minCount 1 ;
-        sh:nodeKind sh:Literal ;
-        sh:path skos:prefLabel ;
-        sh:severity sh:Violation
+        sh:or ( [sh:datatype xsd:date]  [sh:datatype xsd:dateTime]  );        
+        sh:path dct:modified ;
+        sh:severity sh:Violation ;
+        sh:message "dct:modified skal være av type xsd:date eller xsd:dateTime"@nb ;
+    ], [
+        sh:or ([ sh:datatype xsd:date ] [ sh:datatype xsd:dateTime ] );
+        sh:path dct:issued ;
+        sh:severity sh:Violation ;
+        sh:message "dct:issued skal være av type xsd:date eller xsd:dateTime"@nb ;
     ] ;
-    sh:targetClass skos:Concept .
-
-:DateOrDateTimeDataType_Shape
-    a sh:NodeShape ;
-    rdfs:comment "Date time date disjunction shape checks that a datatype property receives a date or a dateTime literal" ;
-    rdfs:label "Date time date disjunction" ;
-    sh:message "The values must be data typed as either xsd:date or xsd:dateTime" ;
-    sh:or ([
-            sh:datatype xsd:date
-        ]
-        [
-            sh:datatype xsd:dateTime
-        ]
-    ) .
+    sh:targetClass dcat:Dataset, dcat:Distribution, dcat:Catalog, dcat:CatalogRecord ;
+    .
 
 :DcatResource_Shape
     a sh:NodeShape ;
     rdfs:comment "the union of Catalog, Dataset and DataService" ;
     rdfs:label "dcat:Resource" ;
-    sh:message "The node is either a Catalog, Dataset or a DataService" ;
+    sh:message "Verdien skal referere til en instans av dcat:Catalog, dcat:Dataset eller dcat:DataService"@nb ;
     sh:or ([
             sh:class dcat:Catalog
         ]
@@ -1035,6 +1338,10 @@
 # -+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-
 # Sjekk mot obligatorisk bruk av kontrollerte vokabularer
 # -+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-
+# ------------------------------------------------------------------------------------------------------------------
+# The constraints for dcat:mediaType, dcat:compressFormat, dcat:packageFormat which are limited to the IANA codelist
+# cannot be expressed in SHACL unless a copy in RDF for the IANA codelist is being created
+# ------------------------------------------------------------------------------------------------------------------
 
 :AccessRightsRestriction
     a sh:NodeShape ;
@@ -1047,6 +1354,7 @@
         ) ;
         sh:minCount 1 ;
         sh:nodeKind sh:IRI ;
+        sh:message "Verdien skal hentes fra kontrollert vokabular http://publications.europa.eu/resource/authority/access-right"@nb ;
         sh:path skos:inScheme
     ] .
 
@@ -1059,33 +1367,7 @@
           [sh:hasValue <http://data.europa.eu/r5r/availability/1.0>]
           [sh:hasValue <https://data.europa.eu/r5r/availability/1.0>] ) ;
         sh:minCount 1 ;
-        sh:nodeKind sh:IRI ;
-        sh:path skos:inScheme
-    ] .
-
-:ContinentRestriction
-    a sh:NodeShape ;
-    rdfs:comment "Continent restriction" ;
-    rdfs:label "Continent restriction" ;
-    sh:property [
-        sh:or (
-          [sh:hasValue <http://publications.europa.eu/resource/authority/continent>]
-          [sh:hasValue <https://publications.europa.eu/resource/authority/continent>] ) ;
-        sh:minCount 1 ;
-        sh:nodeKind sh:IRI ;
-        sh:path skos:inScheme
-    ] .
-
-:CountryRestriction
-    a sh:NodeShape ;
-    rdfs:comment "Country restriction" ;
-    rdfs:label "Country restriction" ;
-    sh:property [
-        sh:or (
-          [sh:hasValue <http://publications.europa.eu/resource/authority/country>]
-          [sh:hasValue <https://publications.europa.eu/resource/authority/country>] ) ;
-        sh:minCount 1 ;
-        sh:nodeKind sh:IRI ;
+        sh:message "Verdien skal hentes fra kontrollert vokabular http://data.europa.eu/r5r/availability/1.0"@nb ;
         sh:path skos:inScheme
     ] .
 
@@ -1093,11 +1375,25 @@
     a sh:NodeShape ;
     rdfs:comment "Spatial Restriction" ;
     rdfs:label "Spatial Restriction" ;
-    sh:or (:CountryRestriction
-                :PlaceRestriction
-                :ContinentRestriction
-                :GeoNamesRestriction
+    sh:property [ 
+        sh:or ( # Et av følgende kontrollerte vokabularer er tillatt         
+            sh:or (  # Country
+                [sh:hasValue <http://publications.europa.eu/resource/authority/country>]
+                [sh:hasValue <https://publications.europa.eu/resource/authority/country>] ) 
+            sh:or ( # Continent
+                [sh:hasValue <http://publications.europa.eu/resource/authority/continent>]
+                [sh:hasValue <https://publications.europa.eu/resource/authority/continent>] )            
+            sh:or ( # Geonames
+                [sh:hasValue <http://sws.geonames.org>]
+                [sh:hasValue <https://sws.geonames.org>] )
+            sh:or ( # Places
+                [sh:hasValue <http://publications.europa.eu/resource/authority/place>]
+                [sh:hasValue <https://publications.europa.eu/resource/authority/place>] ) 
             ) ;
+            sh:minCount 1 ;
+            sh:path skos:inScheme ;
+        ] ;
+     sh:message "Verdien skal hentes fra kontrollerte vokabularer http://publications.europa.eu/resource/authority/continent, http://publications.europa.eu/resource/authority/country, http://publications.europa.eu/resource/authority/place eller http://sws.geonames.org"@nb ;
      .
 
 :DataThemeRestriction
@@ -1109,7 +1405,6 @@
           [sh:hasValue <http://publications.europa.eu/resource/authority/data-theme>]
           [sh:hasValue <https://publications.europa.eu/resource/authority/data-theme>] ) ;
         sh:MinCount 1 ;
-        sh:nodeKind sh:IRI ;
         sh:path skos:inScheme ;
     ] .
 
@@ -1122,18 +1417,19 @@
           [sh:pattern "^http://eurovoc.europa.eu/.+$"]
           [sh:pattern "^https://eurovoc.europa.eu/.+$"] ) ;
         sh:MinCount 1 ;
-        sh:nodeKind sh:IRI ;
+        sh:message "Verdien skal hentes fra kontrollert vokabular http://eurovoc.europa.eu/"@nb ;
         sh:path skos:inScheme
     ] .
 
+# følgende brukes ikke ???
 :nonMandatoryThemeRestriction_ShapeCV
     a sh:NodeShape ;
     rdfs:comment "At least Data-theme is used, when dcat:theme is used"@en ;
-    sh:name "DataThemeRestriction when dcat:theme is not mandatory" ;
+    rdfs:label "DataThemeRestriction when dcat:theme is not mandatory"@en ;
     sh:property [
         sh:qualifiedValueShape [ sh:node :DataThemeRestriction ] ;
         sh:qualifiedMinCount 1 ;
-        sh:nodeKind sh:IRI ;
+        sh:message "Minst én verdi skal hentes fra kontrollert vokabular http://publications.europa.eu/resource/authority/data-theme"@nb ;
         sh:path skos:inScheme ;
     ] ;
     .
@@ -1146,7 +1442,8 @@
         sh:or (
           [sh:hasValue <http://publications.europa.eu/resource/authority/file-type>]
           [sh:hasValue <https://publications.europa.eu/resource/authority/file-type>] ) ;
-        sh:nodeKind sh:IRI ;
+        sh:minCount 1 ;
+        sh:message "Verdien skal hentes fra kontrollert vokabular http://publications.europa.eu/resource/authority/file-type"@nb ;
         sh:path skos:inScheme
     ] .
 
@@ -1159,20 +1456,7 @@
           [sh:hasValue <http://publications.europa.eu/resource/authority/frequency>]
           [sh:hasValue <https://publications.europa.eu/resource/authority/frequency>] ) ;
         sh:minCount 1 ;
-        sh:nodeKind sh:IRI ;
-        sh:path skos:inScheme
-    ] .
-
-:GeoNamesRestriction
-    a sh:NodeShape ;
-    rdfs:comment "Geo names restriction" ;
-    rdfs:label "Geo names restriction" ;
-    sh:property [
-        sh:or (
-          [sh:hasValue <http://sws.geonames.org>]
-          [sh:hasValue <https://sws.geonames.org>] ) ;
-        sh:minCount 1 ;
-        sh:nodeKind sh:IRI ;
+        sh:message "Verdien skal hentes fra kontrollert vokabular http://publications.europa.eu/resource/authority/frequency"@nb ;
         sh:path skos:inScheme
     ] .
 
@@ -1185,7 +1469,7 @@
           [sh:hasValue <http://publications.europa.eu/resource/authority/language>]
           [sh:hasValue <https://publications.europa.eu/resource/authority/language>] ) ;
         sh:minCount 1 ;
-        sh:nodeKind sh:IRI ;
+        sh:message "Verdien skal hentes fra kontrollert vokabular http://publications.europa.eu/resource/authority/language"@nb ;
         sh:path skos:inScheme
     ] .
 
@@ -1198,24 +1482,8 @@
           [sh:hasValue <http://publications.europa.eu/resource/authority/licence>]
           [sh:hasValue <https://publications.europa.eu/resource/authority/licence>] ) ;
         sh:minCount 1 ;
-        sh:nodeKind sh:IRI ;
         sh:path skos:inScheme ;
-# sh:message plassert her blir ikke brukt, ser det ut til
-#        sh:message "Bruk av Kontrollert Vokabular: Det som dct:license peker på finnes ikke i EU sin liste over predefinerte lisenser (http(s)://publications.europa.eu/resource/authority/licence)."@nb ;
-    ] .
-
-:PlaceRestriction
-    a sh:NodeShape ;
-    rdfs:comment "Place restriction" ;
-    rdfs:label "Place restriction" ;
-    sh:property [
-        sh:class skos:ConceptScheme ;
-        sh:or (
-          [sh:hasValue <http://publications.europa.eu/resource/authority/place>]
-          [sh:hasValue <https://publications.europa.eu/resource/authority/place>] ) ;
-        sh:minCount 1 ;
-        sh:nodeKind sh:IRI ;
-        sh:path skos:inScheme
+        sh:message "Verdien skal hentes fra kontrollert vokabular http://publications.europa.eu/resource/authority/licence"@nb ;
     ] .
 
 :PublisherTypeRestriction
@@ -1223,12 +1491,13 @@
     rdfs:comment "Publisher type restriction" ;
     rdfs:label "Publisher type restriction" ;
     sh:property [
-        sh:class skos:ConceptScheme ;
+#        sh:class skos:ConceptScheme ;
+        sh:nodeKind sh:IRI ;
         sh:or (
           [sh:hasValue <http://purl.org/adms/publishertype/1.0>]
           [sh:hasValue <https://purl.org/adms/publishertype/1.0>] ) ;
         sh:minCount 1 ;
-        sh:nodeKind sh:IRI ;
+        sh:message "Verdien skal hentes fra kontrollert vokabular http://purl.org/adms/publishertype/1.0"@nb ;
         sh:path skos:inScheme
     ] .
 
@@ -1237,12 +1506,13 @@
     rdfs:comment "Status restriction" ;
     rdfs:label "Status restriction" ;
     sh:property [
-        sh:class skos:ConceptScheme ;
+#        sh:class skos:ConceptScheme ;
+        sh:nodeKind sh:IRI ;
         sh:or (
           [sh:hasValue <http://purl.org/adms/status/1.0>]
           [sh:hasValue <https://purl.org/adms/status/1.0>] );
         sh:minCount 1 ;
-        sh:nodeKind sh:IRI ;
+        sh:message "Verdien skal hentes fra kontrollert vokabular http://purl.org/adms/status/1.0"@nb ;
         sh:path skos:inScheme
     ] .
 
@@ -1251,91 +1521,62 @@
     rdfs:comment "Legal Resource Type restriction" ;
     rdfs:label "Legal Resource Type restriction" ;
     sh:property [
-        sh:class skos:ConceptScheme ;
+#        sh:class skos:ConceptScheme ;
+        sh:nodeKind sh:IRI ;
         sh:or (
           [sh:hasValue <http://publications.europa.eu/resource/authority/resource-type>]
           [sh:hasValue <https://publications.europa.eu/resource/authority/resource-type>] );
         sh:minCount 1 ;
-        sh:nodeKind sh:IRI ;
+        sh:message "Verdien skal hentes fra kontrollert vokabular http://publications.europa.eu/resource/authority/resource-type"@nb ;
         sh:path skos:inScheme
     ] .
 
-:Legal_Resource_ShapeCV
-    a sh:NodeShape ;
-    sh:property [
-        sh:node :LegalResourceTypeRestriction ;
-        sh:nodeKind sh:IRI ;
-        sh:path dct:type ;
-        sh:severity sh:Violation
-    ] ;
-    sh:targetClass eli:LegalResource .
-
-# Denne brukes av ingen, derfor kommenteres bort i første omgang:
-# :LicenseDocument_ShapeCV
-#    a sh:NodeShape ;
-#    sh:property [
-#        sh:node :LicenseTypeRestriction ;
-#        sh:nodeKind sh:IRI ;
-#        sh:path dct:type
-#    ] ;
-#    sh:targetClass dct:LicenseDocument.
-
-:Catalog_ShapeCV
+# Datasett - sjekk kontrollert vokabular 
+:Dataset_ShapeCV
     a sh:NodeShape ;
     sh:property [
         sh:node :AccessRightsRestriction ;
-        sh:nodeKind sh:IRI ;
         sh:path dct:accessRights ;
-        sh:severity sh:Violation
+        sh:severity sh:Violation ;
+        sh:message "dct:accessRights skal ha verdi hentet fra kontrollert vokabular http://publications.europa.eu/resource/authority/access-right"@nb ;
     ], [
         sh:node :FrequencyRestriction ;
-        sh:nodeKind sh:IRI ;
         sh:path dct:accrualPeriodicity ;
-        sh:severity sh:Violation
+        sh:severity sh:Violation ;
+        sh:message "dct:accrualPeriodicity skal ha verdi hentet verdi fra kontrollert vokabular http://publications.europa.eu/resource/authority/frequency"@nb ;
     ], [
         sh:node :LanguageRestriction ;
-        sh:nodeKind sh:IRI ;
         sh:path dct:language ;
-        sh:severity sh:Violation
+        sh:severity sh:Violation ;
+        sh:message "dct:language skal ha verdi hentet fra kontrollert vokabular http://publications.europa.eu/resource/authority/language"@nb ;
     ], [
-        sh:node :SpatialRestriction ;
-        sh:nodeKind sh:IRI ;
         sh:path dct:spatial ;
         sh:severity sh:Warning ;
-        sh:message "A non managed concept is used to indicate a spatial description, check if a corresponding exist"@en ;
-    ], [
-        sh:node :StatusRestriction ;
-        sh:nodeKind sh:IRI ;
-        sh:path adms:status ;
-        sh:maxCount 1 ;
-        sh:severity sh:Violation
-    ], [
-        sh:or (
-          [sh:pattern "^http://publications.europa.eu/resource/authority/data-theme/.+$"]
-          [sh:pattern "^https://publications.europa.eu/resource/authority/data-theme/.+$"] )
-           ; # Endret til sh:pattern (se netse) fordi sh:hasValue ga merkelig feil
-        sh:nodeKind sh:IRI ;
-        sh:path dcat:themeTaxonomy ;
-    	  sh:description "Multiple themes can be used but at least <http(s)://publications.europa.eu/resource/authority/data-theme> should be present" ;
-        sh:severity sh:Warning
-    ], [
-        sh:or (
-          [sh:pattern "^http://eurovoc.europa.eu/.+$"]
-          [sh:pattern "^https://eurovoc.europa.eu/.+$"] ) ;
-        sh:nodeKind sh:IRI ;
-        sh:path dcat:themeTaxonomy ;
-    	  sh:description "Multiple themes can be used but at least <http://eurovoc.europa.eu/.+> should be present" ;
-        sh:severity sh:Warning ;
+        sh:node :SpatialRestriction ;
+        sh:message "dct:spatial skal ha minst én verdi hentet fra kontrollerte vokabularer http://publications.europa.eu/resource/authority/continent, http://publications.europa.eu/resource/authority/country, http://publications.europa.eu/resource/authority/place eller http://sws.geonames.org"@nb ;
+    ], [ # Norwegian extension
+        sh:node :LicenseTypeRestriction ;
+        sh:path dct:license ;
+        sh:severity sh:Violation ;
+        sh:message "dct:license skal ha verdi hentet fra kontrollert vokabular http://publications.europa.eu/resource/authority/licence"@nb ;
     ] ;
-    sh:targetClass dcat:Catalog.
+    sh:property [
+        sh:path dcat:theme ;
+        sh:qualifiedValueShape [ sh:node :DataThemeRestriction ] ; # NB! kun sjekk på Data-theme, ikke Eurovoc
+        sh:qualifiedMinCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message "dcat:theme skal ha minst én verdi hentet fra kontrollert vokabular http://publications.europa.eu/resource/authority/data-theme"@nb ;
+    ] ;
+    sh:targetClass dcat:Dataset.
 
+#Datatjeneste - sjekker kontrollert vokabular 
 :DataService_ShapeCV
     a sh:NodeShape ;
     sh:property [
         sh:node :AccessRightsRestriction ;
-        sh:nodeKind sh:IRI ;
         sh:path dct:accessRights ;
-        sh:severity sh:Violation
+        sh:severity sh:Violation ;
+        sh:message "dct:accessRights skal ha verdi hentet fra kontrollert vokabular http://publications.europa.eu/resource/authority/access-right"@nb ;
     ] ;
 #--- denne virker ikke helt etter hensikt nå:
 #    sh:property [
@@ -1351,127 +1592,135 @@
 #    ] ;
     sh:targetClass dcat:DataService.
 
-:Dataset_ShapeCV
-    a sh:NodeShape ;
-    sh:property [
-        sh:node :AccessRightsRestriction ;
-        sh:nodeKind sh:IRI ;
-        sh:path dct:accessRights ;
-        sh:severity sh:Violation
-    ], [
-        sh:node :FrequencyRestriction ;
-        sh:nodeKind sh:IRI ;
-        sh:path dct:accrualPeriodicity ;
-        sh:severity sh:Violation
-    ], [
-        sh:node :LanguageRestriction ;
-        sh:nodeKind sh:IRI ;
-        sh:path dct:language ;
-        sh:severity sh:Violation
-    ], [
-        sh:node :SpatialRestriction ;
-        sh:nodeKind sh:IRI ;
-        sh:path dct:spatial ;
-        sh:severity sh:Warning ;
-        sh:message "A non managed concept is used to indicate a spatial description, check if a corresponding exist"@en ;
-    ], [ # Norwegian extension
-        sh:node :LicenseTypeRestriction ;
-        sh:nodeKind sh:IRI ;
-        sh:path dct:license ;
-        sh:severity sh:Violation ;
-        sh:message "Bruk av Kontrollert Vokabular: Det som dct:license peker på finnes ikke i EU sin liste over predefinerte lisenser (http(s)://publications.europa.eu/resource/authority/licence)."@nb ;
-    ] ;
-    sh:property [
-        sh:path dcat:theme ;
-        sh:qualifiedValueShape [ sh:node :DataThemeRestriction ] ; # NB! kun sjekk på Data-theme, ikke Eurovoc
-        sh:qualifiedMinCount 1 ;
-        sh:severity sh:Warning ;
-        sh:message "Data-themes fra EU skal brukes for dcat:theme"@nb ;
-    ] ;
-    sh:targetClass dcat:Dataset.
-
-# ------------------------------------------------------------------------------------------------------------------
-# The constraints for dcat:mediaType, dcat:compressFormat, dcat:packageFormat which are limited to the IANA codelist
-# cannot be expressed in SHACL unless a copy in RDF for the IANA codelist is being created
-# ------------------------------------------------------------------------------------------------------------------
+# Distribusjon - sjekker kontrollert vokabular 
 :Distribution_ShapeCV
     a sh:NodeShape ;
     sh:property [
         sh:node :AccessRightsRestriction ;
-        sh:nodeKind sh:IRI ;
         sh:path dct:accessRights ;
-        sh:severity sh:Violation
+        sh:severity sh:Violation ;
+        sh:message "dct:accessRights skal ha verdi hentet fra kontrollert vokabular http://publications.europa.eu/resource/authority/access-right"@nb ;
     ], [
         sh:node :FileTypeRestriction ;
-        sh:nodeKind sh:IRI ;
         sh:path dct:format ;
-        sh:severity sh:Violation
+        sh:severity sh:Violation ;
+        sh:message "dct:format skal ha verdi hentet fra kontrollert vokabular http://publications.europa.eu/resource/authority/file-type"@nb ;
     ], [
         sh:node :LanguageRestriction ;
-        sh:nodeKind sh:IRI ;
         sh:path dct:language ;
-        sh:severity sh:Violation
+        sh:severity sh:Violation ;
+        sh:message "dct:language en skal ha verdi hentet fra kontrollert vokabular http://publications.europa.eu/resource/authority/language"@nb ;
     ], [
         sh:node :LicenseTypeRestriction ;
-        sh:nodeKind sh:IRI ;
         sh:path dct:license ;
         sh:severity sh:Violation ;
-        sh:message "Bruk av Kontrollert Vokabular: Det som dct:license peker på finnes ikke i EU sin liste over predefinerte lisenser (http(s)://publications.europa.eu/resource/authority/licence)."@nb ;
+        sh:message "dct:license skal ha verdi hentet fra kontrollert vokabular http://publications.europa.eu/resource/authority/licence"@nb ;
     ], [
         sh:node :StatusRestriction ;
-        sh:nodeKind sh:IRI ;
         sh:path adms:status ;
-        sh:severity sh:Violation
+        sh:severity sh:Violation ;
+        sh:message "adms:status skal ha verdi hentet fra kontrollert vokabular http://purl.org/adms/status/1.0"@nb ;
     ], [
         sh:node :AvailabilityRestriction ;
-        sh:nodeKind sh:IRI ;
         sh:path dcatap:availability ;
-        sh:severity sh:Violation
+        sh:severity sh:Violation ;
+        sh:message "dcatap:availability skal ha verdi hentet fra kontrollert vokabular http://data.europa.eu/r5r/availability/1.0"@nb ;
     ], [ ## Norwegian extension
         sh:node :FileTypeRestriction ;
-        sh:nodeKind sh:IRI ;
         sh:path dct:format ;
-        sh:severity sh:Violation
+        sh:severity sh:Violation ;
+        sh:message "dct:format skal ha verdi hentet fra kontrollert vokabular http://publications.europa.eu/resource/authority/file-type"@nb ;
     ] ;
     sh:targetClass dcat:Distribution.
 
-
-:Publisher_ShapeCV
+# Katalog - sjekker kontrollert vokabular
+:Catalog_ShapeCV
     a sh:NodeShape ;
     sh:property [
-        sh:node :PublisherTypeRestriction ;
-        sh:nodeKind sh:IRI ;
-        sh:path dct:type ;
-        sh:severity sh:Violation
-    ] .
+        sh:node :AccessRightsRestriction ;
+        sh:path dct:accessRights ;
+        sh:severity sh:Violation ;
+        sh:message "dct:accessRights skal ha verdi hentet fra kontrollert vokabular http://publications.europa.eu/resource/authority/access-right"@nb ;
+    ], [
+        sh:node :FrequencyRestriction ;
+        sh:path dct:accrualPeriodicity ;
+        sh:severity sh:Violation ;
+        sh:message "dct:accrualPeriodicity skal ha verdi hentet fra kontrollert vokabular http://publications.europa.eu/resource/authority/frequency"@nb ;
+    ], [
+        sh:node :LanguageRestriction ;
+        sh:path dct:language ;
+        sh:severity sh:Violation ;
+        sh:message "dct:language skal ha verdi hentet fra kontrollert vokabular http://publications.europa.eu/resource/authority/language"@nb ;
+    ], [
+        sh:node :SpatialRestriction ;
+        sh:path dct:spatial ;
+        sh:severity sh:Warning ;
+        sh:message "dct:spatial skal ha minst én verdi hentet fra kontrollerte vokabularer http://publications.europa.eu/resource/authority/continent, http://publications.europa.eu/resource/authority/country, http://publications.europa.eu/resource/authority/place eller http://sws.geonames.org"@nb ;
+    ], [
+        sh:node :StatusRestriction ;
+        sh:path adms:status ;
+        sh:severity sh:Violation ;
+        sh:message "adms:status skal ha verdi hentet fra kontrollert vokabular http://purl.org/adms/status/1.0"@nb ;
+    ], [
+        sh:or (
+          [sh:pattern "^http://eurovoc.europa.eu/.+$"]
+          [sh:pattern "^https://eurovoc.europa.eu/.+$"] ) ;
+        sh:path dcat:themeTaxonomy ;
+    	sh:description "dcat:themeTaxonomy bør ha verdi fra <http://eurovoc.europa.eu/.+>"@nb ;
+        sh:severity sh:Warning ;
+    ] ;
+    sh:targetClass dcat:Catalog.
 
+# Regulativ ressurs - sjekker kontrollert vocabular
+:Legal_Resource_ShapeCV
+    a sh:NodeShape ;
+    sh:property [
+        sh:node :LegalResourceTypeRestriction ;
+        sh:path dct:type ;
+        sh:severity sh:Violation ;
+        sh:message "dct:type skal ha verdi hentet fra kontrollert vokabular http://publications.europa.eu/resource/authority/resource-type"@nb ;
+    ] ;
+    sh:targetClass eli:LegalResource .
+
+# Offentlig tjeneste - sjekker kontrollert vokabular 
 :Public_Service_ShapeCV
     a sh:NodeShape ;
     sh:property [
         sh:node :SpatialRestriction ;
-        sh:nodeKind sh:IRI ;
         sh:path dct:spatial ;
         sh:severity sh:Warning ;
-        sh:message "A non managed concept is used to indicate a spatial description, check if a corresponding exist"@en ;
+        sh:message "dct:spatial skal ha minst én verdi hentet fra kontrollerte vokabularer http://publications.europa.eu/resource/authority/continent, http://publications.europa.eu/resource/authority/country, http://publications.europa.eu/resource/authority/place eller http://sws.geonames.org"@nb ;
     ], [
         sh:node :StatusRestriction ;
-        sh:nodeKind sh:IRI ;
         sh:path adms:status ;
-        sh:severity sh:Violation
+        sh:severity sh:Violation ;
+        sh:message "adms:status skal ha verdi hentet fra kontrollert vokabular http://purl.org/adms/status/1.0"@nb ;
     ], [
         sh:node :EurovocThemeRestriction ;
-        sh:nodeKind sh:IRI ;
         sh:path cv:thematicArea ;
-        sh:severity sh:Warning
+        sh:severity sh:Warning ;
+        sh:message "cv:thematicArea skal ha verdi hentet fra kontrollert vokabular http://eurovoc.europa.eu/"@nb ;
     ] ;
     sh:targetClass cpsv:PublicService .
 
+# Regel - sjekker kontrollert vokabular 
 :Rule_ShapeCV
     a sh:NodeShape ;
     sh:property [
         sh:node :LanguageRestriction ;
-        sh:nodeKind sh:IRI ;
         sh:path dct:language ;
-        sh:severity sh:Warning
+        sh:severity sh:Warning ;
+        sh:message "dct:language skal ha verdi hentet fra kontrollert vokabular http://publications.europa.eu/resource/authority/language"@nb ;
     ] ;
     sh:targetClass cpsv:Rule.
+
+# ??? ingen om bruker denne: 
+# Utgiver - sjekker kontrollert vokabular 
+:Publisher_ShapeCV
+    a sh:NodeShape ;
+    sh:property [
+        sh:node :PublisherTypeRestriction ;
+        sh:path dct:type ;
+        sh:severity sh:Violation ;
+        sh:message "dct:type skal ha verdi hentet fra kontrollert vokabular http://purl.org/adms/publishertype/1.0"@nb ;
+    ] .


### PR DESCRIPTION
Oppdaterer shacl-reglene slik at de bl.a. gir brukervennlige tilbakemeldinger, at Terje S kan bruke på workshopen hans om ikke så lenge. 