### PR TITLE
Update DCAT-AP-NO2.0-examples.ttl

### DIFF
--- a/examples/DCAT-AP-NO2.0-examples.ttl
+++ b/examples/DCAT-AP-NO2.0-examples.ttl
@@ -11,7 +11,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix dqvno: <https://data.norge.no/vocabulary/dqvno#> .
-@prefix brregOrg: <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/> .
+@prefix brregOrg: <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/> .
 @prefix euDataTheme: <http://publications.europa.eu/resource/authority/data-theme/> .
 @prefix euDatasetType: <https://data.europa.eu/euodp/en/data/dataset/dataset-type/> .
 @base <https://examples.org/dcatno_Examples#> .
@@ -274,7 +274,7 @@ dqvno:rateOfMissingObjects rdf:type owl:NamedIndividual ,
 :dsBuildings rdf:type owl:NamedIndividual ,
                       dcat:Dataset ;
              dct:conformsTo :qsQualitySpecification ;
-             dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ;
+             dct:publisher <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/991825827> ;
              dct:type euDatasetType:TEST_DATA ;
              dcat:theme euDataTheme:GOVE ;
              dqv:hasQualityAnnotation dqvno:isAuthoritative ,
@@ -293,7 +293,7 @@ dqvno:rateOfMissingObjects rdf:type owl:NamedIndividual ,
 ###  https://examples.org/dcatno_Examples#exCatalog
 :exCatalog rdf:type owl:NamedIndividual ,
                     dcat:Catalog ;
-           dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ;
+           dct:publisher <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/991825827> ;
            dcat:dataset :dsBuildings ;
            dct:description "An example catalog"@en ,
                            "En eksempelkatalog"@nb ;
@@ -392,8 +392,8 @@ dqvno:rateOfMissingObjects rdf:type owl:NamedIndividual ,
                   rdfs:value "Good example dataset with good enough completeness." .
 
 
-###  https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827
-<https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> rdf:type owl:NamedIndividual ,
+###  https://organization-catalog.fellesdatakatalog.digdir.no/organizations/991825827
+<https://organization-catalog.fellesdatakatalog.digdir.no/organizations/991825827> rdf:type owl:NamedIndividual ,
                                                                                               foaf:Agent .
 
 


### PR DESCRIPTION
Oppdaterer DCAT-AP-NO-eksempler, for å rette opp "organization-catalogue" til "organization-catalog"