### PR TITLE
develop -> v3

### DIFF
--- a/.github/workflows/adocs-build-develop.yml
+++ b/.github/workflows/adocs-build-develop.yml
@@ -1,5 +1,9 @@
 name: build adocs
 
+permissions:
+  contents: read
+  pages: write
+
 on:
   push:
     branches:

--- a/.github/workflows/adocs-build-develop.yml
+++ b/.github/workflows/adocs-build-develop.yml
@@ -1,7 +1,7 @@
 name: build adocs
 
 permissions:
-  contents: read
+  contents: write
   pages: write
 
 on:

--- a/.github/workflows/publish-docs-v1.1-to-production.yml
+++ b/.github/workflows/publish-docs-v1.1-to-production.yml
@@ -1,5 +1,8 @@
 name: build adocs and publish v1.1 to production
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/publish-docs-v2-to-production.yml
+++ b/.github/workflows/publish-docs-v2-to-production.yml
@@ -1,5 +1,8 @@
 name: build adocs and publish v2 to production (.../v.2.2)
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/publish-docs-v3-to-production.yml
+++ b/.github/workflows/publish-docs-v3-to-production.yml
@@ -1,5 +1,8 @@
 name: build adocs and publish v3 to production
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/publish-ontology-v3-to-production.yml
+++ b/.github/workflows/publish-ontology-v3-to-production.yml
@@ -1,5 +1,8 @@
 name: Publish ontology to data.norge.no/vocabulary
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/examples/test2.ttl
+++ b/examples/test2.ttl
@@ -17,6 +17,7 @@
 <https://example.com/test/relasjon/begrep> a dcat:Dataset ;
     dct:creator <https://data.brreg.no/enhetsregisteret/api/enheter/991825827> ;
     dct:description "Dette er en test av å relatere til begrep i forbindelse med høsting av datasett."@nb ;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
     dct:language <http://publications.europa.eu/resource/authority/language/NOR> ;
     dct:publisher <https://data.brreg.no/enhetsregisteret/api/enheter/991825827> ;
     dct:subject <https://data.nav.no/begrep/BEGREP-261>,

--- a/ontology/dcatno.ttl
+++ b/ontology/dcatno.ttl
@@ -23,8 +23,8 @@
     "This document specifies the Norwegian extensions in DCAT-AP-NO, currently not the whole DCAT-AP-NO."@en ,
     "Denne versjonen spesifiserer norske utvidelser i DCAT-AP-NO, foreløpig ikke hele DCAT-AP-NO"@nb ;
   rdfs:isDefinedBy "Digitaliseringsdirektoratet"@nb , "Norwegian Digitalisation Agency"@en ;
-  dct:modified "2023-05-22"^^xsd:date ;
-  owl:versionIRI <dcatno:0.7> ;
+  dct:modified "2026-02-25"^^xsd:date ;
+  owl:versionIRI <dcatno:0.8> ;
   rdfs:comment
     "Only the extensions with the namespace dcatno are specified in this version"@en ,
     "Kun utvidelsene med navnerom dcatno er spesifisert i denne versjonen."@nb ;
@@ -46,8 +46,6 @@
 dcatno:containsService a owl:ObjectProperty , rdf:Property ;
   rdfs:subPropertyOf dct:hasPart , rdfs:member ;
   rdfs:label "contains service"@en , "inneholder tjeneste"@nb ;
-  rdfs:domain dcat:Catalog ;
-  rdfs:range cpsvno:Service, cpsv:PublicService ;
   rdfs:comment
     "To refer to a (public) service that is in the catalog."@en ,
     "Brukes til å referere til en (offentlig) tjeneste som er i katalogen."@nb ;
@@ -57,8 +55,6 @@ dcatno:containsService a owl:ObjectProperty , rdf:Property ;
 dcatno:containsEvent a owl:ObjectProperty , rdf:Property ;
   rdfs:subPropertyOf dct:hasPart , rdfs:member ;
   rdfs:label "contains event"@en , "inneholder hendelse"@nb ;
-  rdfs:domain dcat:Catalog;
-  rdfs:range cv:Event ;
   rdfs:comment
     "To refer to an event that is in the catalog."@en ,
     "Brukes til å referere til en hendelse som er i katalogen."@nb ;


### PR DESCRIPTION
(trinn 2 av 2) For å få de siste endringene (feiloppretting i ontologien dcatno.ttl) fra develop- til v3-branch og derfra til data.norge.no. 