### PR TITLE
chore: migrate v3 publish workflows to reusable workflow

### DIFF
--- a/.github/workflows/adocs-build-develop.yml
+++ b/.github/workflows/adocs-build-develop.yml
@@ -2,7 +2,6 @@ name: build adocs
 
 permissions:
   contents: write
-  pages: write
 
 on:
   push:
@@ -12,36 +11,14 @@ on:
       - docs/**
 
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
-    name: asciidoctor build
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor-pdf -D docs -o files/dcat-ap-no.pdf -a lang=nb docs/main.adoc"
-        continue-on-error: true
-        
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+  build-adocs:
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-github-pages.yaml@main
+    with:
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/dcat-ap-no.pdf -a lang=nb docs/main.adoc
+      publish_branch: gh-pages
+      publish_dir: ./docs
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/adocs-build-develop.yml
+++ b/.github/workflows/adocs-build-develop.yml
@@ -17,7 +17,7 @@ jobs:
     name: asciidoctor build
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: true
           fetch-depth: 0
@@ -29,19 +29,19 @@ jobs:
 
       - name: Build html
         id: adocbuild
-        uses: tonynv/asciidoctor-action@master
+        uses: Analog-inc/asciidoctor-action@master
         with:
-          program: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
+          shellcommand: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
 
       - name: Build pdf
         id: adocbuild_pdf
-        uses: tonynv/asciidoctor-action@master
+        uses: Analog-inc/asciidoctor-action@master
         with:
-          program: "asciidoctor-pdf -D docs -o files/dcat-ap-no.pdf -a lang=nb docs/main.adoc"
+          shellcommand: "asciidoctor-pdf -D docs -o files/dcat-ap-no.pdf -a lang=nb docs/main.adoc"
         continue-on-error: true
         
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs

--- a/.github/workflows/publish-docs-v1.1-to-production.yml
+++ b/.github/workflows/publish-docs-v1.1-to-production.yml
@@ -12,49 +12,25 @@ on:
   workflow_dispatch:
 
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
-    name: asciidoctor build
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          ref: v1.1
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor-pdf -D docs -o files/dcat-ap-no.pdf -a lang=nb docs/main.adoc"
-        continue-on-error: true
-
-      - name: Upload rdf to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@84beeeacd364f310ef6a253bc079354cdf62e5dd
-        id: upload-rdf
-        with:
-          ontology-type: "specification"
-          ontology: "dcat-ap-no"
-          version: "v1.1"
-          host: "https://fellesdatakatalog.digdir.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}
-          files: |
-            docs/index.html text/html nb
-            docs/files/dcat-ap-no.pdf application/pdf nb files/dcat-ap-no.pdf
-            docs/files/dcat-ap-no-1.1p2.uxf text/xml nb files/dcat-ap-no-1.1p2.uxf
-            docs/files/dcat-ap-no-1.1p3.png image/png nb files/dcat-ap-no-1.1p3.png
-            docs/images/dcat-ap-no-1-1-diagram.png image/png nb images/dcat-ap-no-1-1-diagram.png
-            docs/images/dcat-ap-no-1.1p3.png image/png nb images/dcat-ap-no-1.1p3.png
+  upload-files-to-production:
+    name: Upload specification to static-rdf-server
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      ref: v1.1
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/dcat-ap-no.pdf -a lang=nb docs/main.adoc
+      files: |
+        docs/index.html text/html nb
+        docs/files/dcat-ap-no.pdf application/pdf nb files/dcat-ap-no.pdf
+        docs/files/dcat-ap-no-1.1p2.uxf text/xml nb files/dcat-ap-no-1.1p2.uxf
+        docs/files/dcat-ap-no-1.1p3.png image/png nb files/dcat-ap-no-1.1p3.png
+        docs/images/dcat-ap-no-1-1-diagram.png image/png nb images/dcat-ap-no-1-1-diagram.png
+        docs/images/dcat-ap-no-1.1p3.png image/png nb images/dcat-ap-no-1.1p3.png
+      host: https://fellesdatakatalog.digdir.no
+      ontology: dcat-ap-no
+      ontology-type: specification
+      version: v1.1
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}

--- a/.github/workflows/publish-docs-v1.1-to-production.yml
+++ b/.github/workflows/publish-docs-v1.1-to-production.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: v1.1
           submodules: true
@@ -31,19 +31,19 @@ jobs:
 
       - name: Build html
         id: adocbuild
-        uses: tonynv/asciidoctor-action@master
+        uses: Analog-inc/asciidoctor-action@master
         with:
-          program: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
+          shellcommand: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
 
       - name: Build pdf
         id: adocbuild_pdf
-        uses: tonynv/asciidoctor-action@master
+        uses: Analog-inc/asciidoctor-action@master
         with:
-          program: "asciidoctor-pdf -D docs -o files/dcat-ap-no.pdf -a lang=nb docs/main.adoc"
+          shellcommand: "asciidoctor-pdf -D docs -o files/dcat-ap-no.pdf -a lang=nb docs/main.adoc"
         continue-on-error: true
 
       - name: Upload rdf to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@v3.2.0
+        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@84beeeacd364f310ef6a253bc079354cdf62e5dd
         id: upload-rdf
         with:
           ontology-type: "specification"

--- a/.github/workflows/publish-docs-v2-to-production.yml
+++ b/.github/workflows/publish-docs-v2-to-production.yml
@@ -12,40 +12,21 @@ on:
   workflow_dispatch:
 
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
-    name: asciidoctor build
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          ref: v2
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Upload rdf to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@84beeeacd364f310ef6a253bc079354cdf62e5dd
-        id: upload-rdf
-        with:
-          ontology-type: "specification"
-          ontology: "dcat-ap-no"
-          version: "v2.2"
-          host: "https://data.norge.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}
-          files: |
-            docs/index.html text/html nb
-            docs/files/DCAT-AP-NO2_20210903.eap application/octet-stream nb files/DCAT-AP-NO2_20210903.eap
-            docs/images/digitaliseringsdirektoratet.png image/png nb images/digitaliseringsdirektoratet.png
-            docs/images/DCAT-AP-NO2_20210903.png image/png nb images/DCAT-AP-NO2_20210903.png
+  upload-files-to-production:
+    name: Upload specification to static-rdf-server
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      ref: v2
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      files: |
+        docs/index.html text/html nb
+        docs/files/DCAT-AP-NO2_20210903.eap application/octet-stream nb files/DCAT-AP-NO2_20210903.eap
+        docs/images/digitaliseringsdirektoratet.png image/png nb images/digitaliseringsdirektoratet.png
+        docs/images/DCAT-AP-NO2_20210903.png image/png nb images/DCAT-AP-NO2_20210903.png
+      host: https://data.norge.no
+      ontology: dcat-ap-no
+      ontology-type: specification
+      version: v2.2
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}

--- a/.github/workflows/publish-docs-v2-to-production.yml
+++ b/.github/workflows/publish-docs-v2-to-production.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: v2
           submodules: true
@@ -31,12 +31,12 @@ jobs:
 
       - name: Build html
         id: adocbuild
-        uses: tonynv/asciidoctor-action@master
+        uses: Analog-inc/asciidoctor-action@master
         with:
-          program: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
+          shellcommand: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
 
       - name: Upload rdf to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@v3.2.0
+        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@84beeeacd364f310ef6a253bc079354cdf62e5dd
         id: upload-rdf
         with:
           ontology-type: "specification"

--- a/.github/workflows/publish-docs-v3-to-production.yml
+++ b/.github/workflows/publish-docs-v3-to-production.yml
@@ -12,67 +12,42 @@ on:
   workflow_dispatch:
 
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
-    name: asciidoctor build
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          ref: v3
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild_html
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-            shellcommand: "asciidoctor-pdf -D docs -o files/dcat-ap-no.pdf -a lang=nb docs/main.adoc"
-        continue-on-error: true
-
-      - name: Upload files to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@84beeeacd364f310ef6a253bc079354cdf62e5dd
-        id: upload-files
-        with:
-          ontology-type: "specification"
-          ontology: "dcat-ap-no"
-          host: "https://data.norge.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}
-          files: |
-            docs/index.html text/html nb
-            docs/files/dcat-ap-no.pdf application/pdf nb files/dcat-ap-no.pdf
-            docs/images/Digdir.png image/png nb images/Digdir.png
-            docs/images/datasett-distribusjon-datatjeneste.png image/png nb images/datasett-distribusjon-datatjeneste.png
-            docs/images/DCAT-AP-NO-forenklet-fremstilling.png image/png nb images/DCAT-AP-NO-forenklet-fremstilling.png
-            docs/images/DCAT-AP-NO-klasser.png image/png nb images/DCAT-AP-NO-klasser.png
-            docs/images/Figur-ordnet-datasettserie.png image/png nb images/Figur-ordnet-datasettserie.png
-            docs/images/Klassen-Aktør.png image/png nb images/Klassen-Aktør.png
-            docs/images/Klassen-Datasett.png image/png nb images/Klassen-Datasett.png
-            docs/images/Klassen-Datasettserie.png image/png nb images/Klassen-Datasettserie.png
-            docs/images/Klassen-Datatjeneste.png image/png nb images/Klassen-Datatjeneste.png
-            docs/images/Klassen-Distribusjon.png image/png nb images/Klassen-Distribusjon.png
-            docs/images/Klassen-Gebyr.png image/png nb images/Klassen-Gebyr.png
-            docs/images/Klassen-Identifikator.png image/png nb images/Klassen-Identifikator.png
-            docs/images/Klassen-Katalog.png image/png nb images/Klassen-Katalog.png
-            docs/images/Klassen-KatalogisertRessurs.png image/png nb images/Klassen-KatalogisertRessurs.png
-            docs/images/Klassen-Katalogpost.png image/png nb images/Klassen-Katalogpost.png
-            docs/images/Klassen-Kontaktopplysning.png image/png nb images/Klassen-Kontaktopplysning.png
-            docs/images/Klassen-RegulativRessurs.png image/png nb images/Klassen-RegulativRessurs.png
-            docs/images/Klassen-Relasjon.png image/png nb images/Klassen-Relasjon.png
-            docs/images/Klassen-Rettighetserklæring.png image/png nb images/Klassen-Rettighetserklæring.png
-            docs/images/Klassen-Sjekksum.png image/png nb images/Klassen-Sjekksum.png
-            docs/images/Klassen-Standard.png image/png nb images/Klassen-Standard.png
-            docs/images/Klassen-Tidsrom.png image/png nb images/Klassen-Tidsrom.png
-
+  upload-files-to-production:
+    name: Upload specification to static-rdf-server
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      ref: v3
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/dcat-ap-no.pdf -a lang=nb docs/main.adoc
+      files: |
+        docs/index.html text/html nb
+        docs/files/dcat-ap-no.pdf application/pdf nb files/dcat-ap-no.pdf
+        docs/images/Digdir.png image/png nb images/Digdir.png
+        docs/images/datasett-distribusjon-datatjeneste.png image/png nb images/datasett-distribusjon-datatjeneste.png
+        docs/images/DCAT-AP-NO-forenklet-fremstilling.png image/png nb images/DCAT-AP-NO-forenklet-fremstilling.png
+        docs/images/DCAT-AP-NO-klasser.png image/png nb images/DCAT-AP-NO-klasser.png
+        docs/images/Figur-ordnet-datasettserie.png image/png nb images/Figur-ordnet-datasettserie.png
+        docs/images/Klassen-Aktør.png image/png nb images/Klassen-Aktør.png
+        docs/images/Klassen-Datasett.png image/png nb images/Klassen-Datasett.png
+        docs/images/Klassen-Datasettserie.png image/png nb images/Klassen-Datasettserie.png
+        docs/images/Klassen-Datatjeneste.png image/png nb images/Klassen-Datatjeneste.png
+        docs/images/Klassen-Distribusjon.png image/png nb images/Klassen-Distribusjon.png
+        docs/images/Klassen-Gebyr.png image/png nb images/Klassen-Gebyr.png
+        docs/images/Klassen-Identifikator.png image/png nb images/Klassen-Identifikator.png
+        docs/images/Klassen-Katalog.png image/png nb images/Klassen-Katalog.png
+        docs/images/Klassen-KatalogisertRessurs.png image/png nb images/Klassen-KatalogisertRessurs.png
+        docs/images/Klassen-Katalogpost.png image/png nb images/Klassen-Katalogpost.png
+        docs/images/Klassen-Kontaktopplysning.png image/png nb images/Klassen-Kontaktopplysning.png
+        docs/images/Klassen-RegulativRessurs.png image/png nb images/Klassen-RegulativRessurs.png
+        docs/images/Klassen-Relasjon.png image/png nb images/Klassen-Relasjon.png
+        docs/images/Klassen-Rettighetserklæring.png image/png nb images/Klassen-Rettighetserklæring.png
+        docs/images/Klassen-Sjekksum.png image/png nb images/Klassen-Sjekksum.png
+        docs/images/Klassen-Standard.png image/png nb images/Klassen-Standard.png
+        docs/images/Klassen-Tidsrom.png image/png nb images/Klassen-Tidsrom.png
+      host: https://data.norge.no
+      ontology: dcat-ap-no
+      ontology-type: specification
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}

--- a/.github/workflows/publish-docs-v3-to-production.yml
+++ b/.github/workflows/publish-docs-v3-to-production.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: v3
           submodules: true
@@ -31,19 +31,19 @@ jobs:
 
       - name: Build html
         id: adocbuild_html
-        uses: tonynv/asciidoctor-action@master
+        uses: Analog-inc/asciidoctor-action@master
         with:
-          program: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
+          shellcommand: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
 
       - name: Build pdf
         id: adocbuild_pdf
-        uses: tonynv/asciidoctor-action@master
+        uses: Analog-inc/asciidoctor-action@master
         with:
-            program: "asciidoctor-pdf -D docs -o files/dcat-ap-no.pdf -a lang=nb docs/main.adoc"
+            shellcommand: "asciidoctor-pdf -D docs -o files/dcat-ap-no.pdf -a lang=nb docs/main.adoc"
         continue-on-error: true
 
       - name: Upload files to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@v3.2.0
+        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@84beeeacd364f310ef6a253bc079354cdf62e5dd
         id: upload-files
         with:
           ontology-type: "specification"

--- a/.github/workflows/publish-ontology-v3-to-production.yml
+++ b/.github/workflows/publish-ontology-v3-to-production.yml
@@ -12,45 +12,20 @@ on:
   workflow_dispatch:
 
 jobs:
-  test_uploading_of_file:
+  upload-files-to-production:
     name: Upload vocabulary to static-rdf-server
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          ref: v3
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html en
-        id: adocbuild_html_en
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor -a data-uri -D ontology -o index-en.html -a lang=en ontology/main-en.adoc"
-
-      - name: Build html nb
-        id: adocbuild_html_nb
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor -a data-uri -D ontology -o index-nb.html -a lang=nb ontology/main-nb.adoc"
-
-      - name: Upload files to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@84beeeacd364f310ef6a253bc079354cdf62e5dd
-        id: upload-files
-        with:
-          ontology-type: "vocabulary"
-          ontology: "dcatno"
-          host: "https://data.norge.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}
-          files: |
-            ontology/dcatno.ttl text/turtle en 
-            ontology/index-nb.html text/html nb
-            ontology/index-en.html text/html en
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      ref: v3
+      program_html: |
+        asciidoctor -a data-uri -D ontology -o index-en.html -a lang=en ontology/main-en.adoc
+        asciidoctor -a data-uri -D ontology -o index-nb.html -a lang=nb ontology/main-nb.adoc
+      files: |
+        ontology/dcatno.ttl text/turtle en
+        ontology/index-nb.html text/html nb
+        ontology/index-en.html text/html en
+      host: https://data.norge.no
+      ontology: dcatno
+      ontology-type: vocabulary
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}

--- a/.github/workflows/publish-ontology-v3-to-production.yml
+++ b/.github/workflows/publish-ontology-v3-to-production.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: v3
           submodules: true
@@ -32,18 +32,18 @@ jobs:
 
       - name: Build html en
         id: adocbuild_html_en
-        uses: tonynv/asciidoctor-action@master
+        uses: Analog-inc/asciidoctor-action@master
         with:
-          program: "asciidoctor -a data-uri -D ontology -o index-en.html -a lang=en ontology/main-en.adoc"
+          shellcommand: "asciidoctor -a data-uri -D ontology -o index-en.html -a lang=en ontology/main-en.adoc"
 
       - name: Build html nb
         id: adocbuild_html_nb
-        uses: tonynv/asciidoctor-action@master
+        uses: Analog-inc/asciidoctor-action@master
         with:
-          program: "asciidoctor -a data-uri -D ontology -o index-nb.html -a lang=nb ontology/main-nb.adoc"
+          shellcommand: "asciidoctor -a data-uri -D ontology -o index-nb.html -a lang=nb ontology/main-nb.adoc"
 
       - name: Upload files to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@v3.2.0
+        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@84beeeacd364f310ef6a253bc079354cdf62e5dd
         id: upload-files
         with:
           ontology-type: "vocabulary"

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dcat-ap-no.pdf
 !slash/index.html
 !ontology/index.html
 .DS_Store
+.idea


### PR DESCRIPTION
# Summary

- Migrate `publish-docs-v3-to-production.yml` and `publish-ontology-v3-to-production.yml` to call the central reusable workflow in `Informasjonsforvaltning/workflows`
- Promotes the already-merged `develop` migration to `v3`; without this, production publishes still run the old inline workflows (push events use the file on the target branch)
- Brings `v3` fully in sync with `develop` (also updates the dormant v1.1/v2 workflow copies + a `.gitignore` line)
- No auto-trigger: only touches `.github/workflows/**` + `.gitignore`; verify post-merge via `workflow_dispatch` from `v3`