### PR TITLE
chore: migrate v2 publish workflow to reusable workflow

### DIFF
--- a/.github/workflows/publish-docs-v2-to-production.yml
+++ b/.github/workflows/publish-docs-v2-to-production.yml
@@ -1,5 +1,8 @@
 name: build adocs and publish v2 to production (.../v.2.2)
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -9,40 +12,21 @@ on:
   workflow_dispatch:
 
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
-    name: asciidoctor build
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: v2
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Upload rdf to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@v3.2.0
-        id: upload-rdf
-        with:
-          ontology-type: "specification"
-          ontology: "dcat-ap-no"
-          version: "v2.2"
-          host: "https://data.norge.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}
-          files: |
-            docs/index.html text/html nb
-            docs/files/DCAT-AP-NO2_20210903.eap application/octet-stream nb files/DCAT-AP-NO2_20210903.eap
-            docs/images/digitaliseringsdirektoratet.png image/png nb images/digitaliseringsdirektoratet.png
-            docs/images/DCAT-AP-NO2_20210903.png image/png nb images/DCAT-AP-NO2_20210903.png
+  upload-files-to-production:
+    name: Upload specification to static-rdf-server
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      ref: v2
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      files: |
+        docs/index.html text/html nb
+        docs/files/DCAT-AP-NO2_20210903.eap application/octet-stream nb files/DCAT-AP-NO2_20210903.eap
+        docs/images/digitaliseringsdirektoratet.png image/png nb images/digitaliseringsdirektoratet.png
+        docs/images/DCAT-AP-NO2_20210903.png image/png nb images/DCAT-AP-NO2_20210903.png
+      host: https://data.norge.no
+      ontology: dcat-ap-no
+      ontology-type: specification
+      version: v2.2
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}


### PR DESCRIPTION
# Summary

- Migrate `publish-docs-v2-to-production.yml` to call the central reusable workflow in `Informasjonsforvaltning/workflows`
- Forward-ports the migration from `develop` to the frozen `v2` branch (selective checkout — does not pull in unrelated v3-era content)
- No auto-trigger: only touches `.github/workflows/**`; verify post-merge via `workflow_dispatch` from `v2`