### PR TITLE
chore: migrate v1.1 publish workflow to reusable workflow

### DIFF
--- a/.github/workflows/publish-docs-v1.1-to-production.yml
+++ b/.github/workflows/publish-docs-v1.1-to-production.yml
@@ -1,5 +1,8 @@
 name: build adocs and publish v1.1 to production
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -9,49 +12,25 @@ on:
   workflow_dispatch:
 
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
-    name: asciidoctor build
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          ref: v1.1
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor-pdf -D docs -o files/dcat-ap-no.pdf -a lang=nb docs/main.adoc"
-        continue-on-error: true
-
-      - name: Upload rdf to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@v3.2.0
-        id: upload-rdf
-        with:
-          ontology-type: "specification"
-          ontology: "dcat-ap-no"
-          version: "v1.1"
-          host: "https://fellesdatakatalog.digdir.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}
-          files: |
-            docs/index.html text/html nb
-            docs/files/dcat-ap-no.pdf application/pdf nb files/dcat-ap-no.pdf
-            docs/files/dcat-ap-no-1.1p2.uxf text/xml nb files/dcat-ap-no-1.1p2.uxf
-            docs/files/dcat-ap-no-1.1p3.png image/png nb files/dcat-ap-no-1.1p3.png
-            docs/images/dcat-ap-no-1-1-diagram.png image/png nb images/dcat-ap-no-1-1-diagram.png
-            docs/images/dcat-ap-no-1.1p3.png image/png nb images/dcat-ap-no-1.1p3.png
+  upload-files-to-production:
+    name: Upload specification to static-rdf-server
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      ref: v1.1
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/dcat-ap-no.pdf -a lang=nb docs/main.adoc
+      files: |
+        docs/index.html text/html nb
+        docs/files/dcat-ap-no.pdf application/pdf nb files/dcat-ap-no.pdf
+        docs/files/dcat-ap-no-1.1p2.uxf text/xml nb files/dcat-ap-no-1.1p2.uxf
+        docs/files/dcat-ap-no-1.1p3.png image/png nb files/dcat-ap-no-1.1p3.png
+        docs/images/dcat-ap-no-1-1-diagram.png image/png nb images/dcat-ap-no-1-1-diagram.png
+        docs/images/dcat-ap-no-1.1p3.png image/png nb images/dcat-ap-no-1.1p3.png
+      host: https://fellesdatakatalog.digdir.no
+      ontology: dcat-ap-no
+      ontology-type: specification
+      version: v1.1
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}


### PR DESCRIPTION
# Summary

- Migrate `publish-docs-v1.1-to-production.yml` to call the central reusable workflow in `Informasjonsforvaltning/workflows`
- Forward-ports the migration from `develop` to the frozen `v1.1` branch (selective checkout — does not pull in unrelated v3-era content)
- No auto-trigger: only touches `.github/workflows/**`; verify post-merge via `workflow_dispatch` from `v1.1`